### PR TITLE
feat: support IBM Java ORB's java.util.Date expectations

### DIFF
--- a/testify/src/main/java/testify/hex/HexBuilder.java
+++ b/testify/src/main/java/testify/hex/HexBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 IBM Corporation and others.
+ * Copyright 2025 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,6 +95,12 @@ public class HexBuilder {
         return this;
     }
 
+    /** write some raw data, without any length */
+    public HexBuilder bytes(byte[] bytes) {
+        for (byte b: bytes) oct(0xFF & b);
+        return this;
+    }
+
     /** write a string, including the length and a null terminator */
     public HexBuilder str(String s) {
         assert s.matches("\\p{ASCII}*");
@@ -125,5 +131,12 @@ public class HexBuilder {
         try (Formatter f = this.f){
             return f.toString();
         }
+    }
+
+    public String dump() {
+        StringBuilder sb = new StringBuilder(hex());
+        for (int i = 8; i < sb.length(); i+=9)
+            sb.insert(i, (0==(i+1)%36) ? '\n' : ' ');
+        return sb.toString();
     }
 }

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OBCORBA/ORB_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OBCORBA/ORB_impl.java
@@ -110,6 +110,8 @@ import org.apache.yoko.orb.OCI.Plugin;
 import org.apache.yoko.orb.cmsf.CmsfClientInterceptor;
 import org.apache.yoko.orb.cmsf.CmsfIORInterceptor;
 import org.apache.yoko.orb.cmsf.CmsfServerInterceptor;
+import org.apache.yoko.orb.rofl.RoflClientInterceptor;
+import org.apache.yoko.orb.rofl.RoflServerInterceptor;
 import org.apache.yoko.orb.yasf.YasfClientInterceptor;
 import org.apache.yoko.orb.yasf.YasfIORInterceptor;
 import org.apache.yoko.orb.yasf.YasfServerInterceptor;
@@ -381,6 +383,15 @@ public class ORB_impl extends ORBSingleton {
                 piManager.addIORInterceptor(new YasfIORInterceptor(), true);
                 piManager.addClientRequestInterceptor(new YasfClientInterceptor());
                 piManager.addServerRequestInterceptor(new YasfServerInterceptor(piManager.allocateSlotId()));
+            } catch (DuplicateName ex) {
+                throw Assert.fail(ex);
+            }
+
+            // Install interceptors for Remote Orb Finessing Logic
+            try {
+                // read only, so no IOR interceptor required
+                piManager.addClientRequestInterceptor(new RoflClientInterceptor());
+                piManager.addServerRequestInterceptor(new RoflServerInterceptor(piManager.allocateSlotId()));
             } catch (DuplicateName ex) {
                 throw Assert.fail(ex);
             }

--- a/yoko-core/src/main/java/org/apache/yoko/orb/rofl/RoflClientInterceptor.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/rofl/RoflClientInterceptor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an \"AS IS\" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.yoko.orb.rofl;
+
+import org.apache.yoko.util.rofl.Rofl;
+import org.apache.yoko.util.rofl.RoflThreadLocal;
+import org.omg.CORBA.BAD_PARAM;
+import org.omg.CORBA.LocalObject;
+import org.omg.IOP.TaggedComponent;
+import org.omg.PortableInterceptor.ClientRequestInfo;
+import org.omg.PortableInterceptor.ClientRequestInterceptor;
+import org.omg.PortableInterceptor.ForwardRequest;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.apache.yoko.util.MinorCodes.MinorInvalidComponentId;
+import static org.apache.yoko.util.rofl.Rofl.RemoteOrb.IBM;
+
+public class RoflClientInterceptor extends LocalObject implements ClientRequestInterceptor {
+    private static final String NAME = RoflClientInterceptor.class.getName();
+
+    @Override
+    public void send_request(ClientRequestInfo ri) throws ForwardRequest {
+        Rofl rofl = Rofl.NONE;
+        try {
+            TaggedComponent tc = ri.get_effective_component(IBM.tagComponentId);
+            rofl = IBM.createRofl(tc.component_data);
+        } catch (BAD_PARAM e) {
+            if (e.minor != MinorInvalidComponentId) {
+                throw e;
+            }
+        }
+        RoflThreadLocal.push(rofl);
+    }
+
+    public void send_poll(ClientRequestInfo ri) {}
+    public void receive_reply(ClientRequestInfo ri) {
+        RoflThreadLocal.pop();
+    }
+    public void receive_exception(ClientRequestInfo ri) {
+        RoflThreadLocal.pop();
+    }
+    public void receive_other(ClientRequestInfo ri) {
+        RoflThreadLocal.pop();
+    }
+    public String name() {
+        return NAME;
+    }
+    public void destroy() {}
+    private void readObject(ObjectInputStream ios) throws IOException { throw new NotSerializableException(NAME); }
+    private void writeObject(ObjectOutputStream oos) throws IOException { throw new NotSerializableException(NAME); }
+}

--- a/yoko-core/src/main/java/org/apache/yoko/orb/rofl/RoflServerInterceptor.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/rofl/RoflServerInterceptor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an \"AS IS\" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.yoko.orb.rofl;
+
+import org.apache.yoko.util.rofl.Rofl;
+import org.apache.yoko.util.rofl.RoflThreadLocal;
+import org.omg.CORBA.Any;
+import org.omg.CORBA.BAD_PARAM;
+import org.omg.CORBA.INTERNAL;
+import org.omg.CORBA.LocalObject;
+import org.omg.CORBA.ORB;
+import org.omg.IOP.ServiceContext;
+import org.omg.PortableInterceptor.ForwardRequest;
+import org.omg.PortableInterceptor.InvalidSlot;
+import org.omg.PortableInterceptor.ServerRequestInfo;
+import org.omg.PortableInterceptor.ServerRequestInterceptor;
+
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.apache.yoko.util.MinorCodes.MinorInvalidServiceContextId;
+import static org.apache.yoko.util.rofl.Rofl.RemoteOrb.IBM;
+
+public class RoflServerInterceptor extends LocalObject implements ServerRequestInterceptor {
+    private static final String NAME = RoflServerInterceptor.class.getName();
+    private final int slotId;
+
+    public RoflServerInterceptor(int slotId) {
+        this.slotId = slotId;
+    }
+    public void receive_request_service_contexts(ServerRequestInfo ri) throws ForwardRequest {
+        RoflThreadLocal.reset();
+        saveRoflToSlot(readRofl(ri), ri);
+    }
+    public void receive_request(ServerRequestInfo ri) {}
+    public void send_reply(ServerRequestInfo ri) { RoflThreadLocal.push(loadRoflFromSlot(ri)); }
+    public void send_exception(ServerRequestInfo ri) { RoflThreadLocal.push(loadRoflFromSlot(ri)); }
+    public void send_other(ServerRequestInfo ri) { RoflThreadLocal.push(loadRoflFromSlot(ri)); }
+    public String name() { return NAME; }
+    public void destroy() {}
+    private void readObject(ObjectInputStream ios) throws IOException { throw new NotSerializableException(NAME);}
+    private void writeObject(ObjectOutputStream oos) throws IOException { throw new NotSerializableException(NAME); }
+
+    private void saveRoflToSlot(Rofl rofl, ServerRequestInfo ri) {
+        Any any = ORB.init().create_any();
+        any.insert_Value(rofl);
+        try {
+            ri.set_slot(slotId, any);
+        } catch (InvalidSlot e) {
+            throw (INTERNAL)(new INTERNAL(e.getMessage())).initCause(e);
+        }
+    }
+
+    private Rofl loadRoflFromSlot(ServerRequestInfo ri) {
+        final Rofl rofl;
+        try {
+            Any any = ri.get_slot(slotId);
+            rofl = (Rofl) any.extract_Value();
+        } catch (InvalidSlot e) {
+            throw (INTERNAL)(new INTERNAL(e.getMessage())).initCause(e);
+        }
+        return rofl;
+    }
+
+    private static Rofl readRofl(ServerRequestInfo ri) {
+        Rofl rofl = Rofl.NONE;
+        try {
+            ServiceContext sc = ri.get_request_service_context(IBM.serviceContextId);
+            rofl = IBM.createRofl(sc.context_data);
+
+        } catch (BAD_PARAM e) {
+            if (e.minor != MinorInvalidServiceContextId) throw e;
+        }
+        return rofl;
+    }
+}

--- a/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/ObjectWriter.java
+++ b/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/ObjectWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 IBM Corporation and others.
+ * Copyright 2025 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 package org.apache.yoko.rmi.impl;
 
 import org.apache.yoko.util.cmsf.CmsfThreadLocal;
+import org.apache.yoko.util.rofl.Interop;
 
 import java.io.Externalizable;
 import java.io.IOException;
@@ -64,7 +65,10 @@ abstract class ObjectWriter extends ObjectOutputStream {
 
             void beforeDefaultWriteObject(ObjectWriter writer) throws IOException {
                 writer.state = IN_DEFAULT_WRITE_OBJECT;
-                writer.writeBoolean(true);
+                String customRepId = writer._desc.getCustomRepositoryID();
+                // some objects need to be written to
+                boolean flag = Interop.flagDefaultWriteObject(customRepId);
+                writer.writeBoolean(flag);
             }
 
             void beforeWriteData(ObjectWriter writer) throws IOException {
@@ -154,9 +158,7 @@ abstract class ObjectWriter extends ObjectOutputStream {
     }
 
     public final void defaultWriteObject() throws IOException {
-        if (_desc == null) {
-            throw new NotActiveException();
-        }
+        if (_desc == null) throw new NotActiveException();
 
         state.beforeDefaultWriteObject(this);
         try {

--- a/yoko-util/src/main/java/org/apache/yoko/util/cmsf/CmsfThreadLocal.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/cmsf/CmsfThreadLocal.java
@@ -17,6 +17,8 @@
  */
 package org.apache.yoko.util.cmsf;
 
+import org.apache.yoko.io.SimplyCloseable;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -85,12 +87,13 @@ public final class CmsfThreadLocal {
         return new CmsfOverride(cmsfInfo.get());
     }
 
-    public static void push(byte cmsfv) {
+    public static SimplyCloseable push(byte cmsfv) {
         final CmsfInfo info = cmsfInfo.get();
         final Version version = Version.get(cmsfv);
         if (LOGGER.isLoggable(Level.FINER))
             LOGGER.finer(String.format("CMSF thread local version pushed onto stack: %s", version));
         info.head = new Frame(version, info.head);
+        return CmsfThreadLocal::pop;
     }
 
     public static byte get() {

--- a/yoko-util/src/main/java/org/apache/yoko/util/rofl/Interop.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/rofl/Interop.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an \"AS IS\" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.yoko.util.rofl;
+
+import static org.apache.yoko.util.rofl.Rofl.RemoteOrb.IBM;
+
+public enum Interop {
+    ;
+
+    /**
+     * There is a mismatch between the defaultWriteObject() behaviour
+     * of java.util.Date in Java 8 and Java 11.
+     * Some ORBs are sensitive to this.
+     * If Yoko is talking to an IBM Java ORB (Java <=8)
+     * mask the defaultWriteObject flag.
+     */
+    public static boolean flagDefaultWriteObject(String customRepId) {
+        if (null == customRepId) return true;
+        if (RoflThreadLocal.get().type() != IBM) return true;
+        if (!customRepId.endsWith(":686A81014B597419")) return true;
+        return !customRepId.startsWith("RMI:org.omg.custom.java.util.Date:");
+    }
+}

--- a/yoko-util/src/main/java/org/apache/yoko/util/rofl/Rofl.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/rofl/Rofl.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an \"AS IS\" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.yoko.util.rofl;
+
+import org.apache.yoko.util.HexConverter;
+
+import java.io.Serializable;
+import java.util.function.Function;
+import java.util.logging.Logger;
+
+import static java.util.Arrays.copyOf;
+import static java.util.logging.Level.WARNING;
+import static org.apache.yoko.util.rofl.Rofl.RemoteOrb.IBM;
+import static org.apache.yoko.util.rofl.Rofl.RemoteOrb.BAD;
+import static org.apache.yoko.util.rofl.Rofl.RemoteOrb.NO_DATA;
+
+/**
+ * <h1>ROFL &mdash; RemoteOrbFinessingLogic</h1>
+ * This class encapsulates all the fixes that affect the stream format when talking to other ORBs.
+ * These will be read in from two sources:
+ * <ul>
+ *     <li>a component tag in an IOR profile</li>
+ *     <li>a service context in a GIOP packet</li>
+ * </ul>
+ * and referred to only when marshalling data.
+ */
+public interface Rofl extends Serializable {
+    Rofl NONE = new NoRofl();
+    enum RemoteOrb {
+        /** The IBM Java ORB */
+        IBM(0x49424D0A, 0x49424D12, IbmRofl::new),
+        BAD,
+        NO_DATA
+        ;
+
+        public final Integer tagComponentId;
+        public final Integer serviceContextId;
+        private final Function<byte[], Rofl> ctor;
+        RemoteOrb() { this(null, null, null); }
+        RemoteOrb(Integer tagComponentId, Integer serviceContextId, Function<byte[], Rofl> ctor) {
+            this.tagComponentId = tagComponentId;
+            this.serviceContextId = serviceContextId;
+            this.ctor = ctor;
+        }
+
+        public Rofl createRofl(byte[] data) {
+            try {
+                return ctor.apply(data);
+            } catch (Throwable t) {
+                Logger.getLogger(Rofl.class.getName() + "." + name()).log(WARNING, "Failed to create ROFL for remote ORB of type " + this, t);
+                return new BadRofl(data, t);
+            }
+        }
+    }
+    RemoteOrb type();
+    default boolean marshalDateLikeJava8() { return type() == IBM; }
+}
+
+class IbmRofl implements Rofl{
+    private static final long serialVersionUID = 1L;
+    public final short major, minor, extended;
+    IbmRofl(byte[] data) {
+        if (data.length != 8) {
+            major = minor = extended = -1;
+            return;
+        }
+        int i = 0;
+        // 1 byte boolean: true iff littleEndian - ignore since Java is big-endian
+        i++;
+        // 1 byte padding - ignore
+        i++;
+        // extended short
+        extended = (short)(((data[i++] & 0xFF) << 8) | (data[i++] & 0xFF));
+        // major short
+        major = (short)(((data[i++] & 0xFF) << 8) | (data[i++] & 0xFF));
+        // minor short
+        minor = (short)(((data[i++] & 0xFF) << 8) | (data[i++] & 0xFF));
+    }
+    public RemoteOrb type() { return IBM; }
+    public String toString() { return String.format("IBM JAVA ORB[major=%04X minor=%04x, extended=%04X]", major, minor, extended); }
+}
+
+class BadRofl implements Rofl {
+    private static final long serialVersionUID = 1L;
+    byte[] data;
+    Throwable cause;
+    BadRofl(byte[] data, Throwable cause) {
+        this.data = data == null ? null : copyOf(data, data.length);
+    }
+    public RemoteOrb type()  { return BAD; }
+    public String toString() { return String.format("UNKNOWN ORB[%s]", HexConverter.octetsToAscii(data)); }
+}
+
+class NoRofl implements Rofl {
+    public RemoteOrb type() { return NO_DATA; }
+    public String toString() { return "NONE"; }
+}

--- a/yoko-util/src/main/java/org/apache/yoko/util/rofl/Rofl.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/rofl/Rofl.java
@@ -25,8 +25,8 @@ import java.util.logging.Logger;
 
 import static java.util.Arrays.copyOf;
 import static java.util.logging.Level.WARNING;
-import static org.apache.yoko.util.rofl.Rofl.RemoteOrb.IBM;
 import static org.apache.yoko.util.rofl.Rofl.RemoteOrb.BAD;
+import static org.apache.yoko.util.rofl.Rofl.RemoteOrb.IBM;
 import static org.apache.yoko.util.rofl.Rofl.RemoteOrb.NO_DATA;
 
 /**
@@ -68,7 +68,6 @@ public interface Rofl extends Serializable {
         }
     }
     RemoteOrb type();
-    default boolean marshalDateLikeJava8() { return type() == IBM; }
 }
 
 class IbmRofl implements Rofl{

--- a/yoko-util/src/main/java/org/apache/yoko/util/rofl/RoflThreadLocal.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/rofl/RoflThreadLocal.java
@@ -60,11 +60,12 @@ public final class RoflThreadLocal {
         return () -> info.override = false;
     }
 
-    public static void push(Rofl rofl) {
+    public static SimplyCloseable push(Rofl rofl) {
         final Stack info = threadLocalStack.get();
         if (LOGGER.isLoggable(Level.FINER))
             LOGGER.finer(String.format("ROFL thread local version pushed onto stack: %s", rofl));
         info.head = new Frame(rofl, info.head);
+        return RoflThreadLocal::pop;
     }
 
     public static Rofl get() {

--- a/yoko-util/src/main/java/org/apache/yoko/util/rofl/RoflThreadLocal.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/rofl/RoflThreadLocal.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an \"AS IS\" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.yoko.util.rofl;
+
+import org.apache.yoko.io.SimplyCloseable;
+import org.apache.yoko.util.yasf.Yasf;
+
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Provides a stack-based approach to track the ROFL settings in effect on the current thread.
+ */
+public final class RoflThreadLocal {
+    private static final Logger LOGGER = Logger.getLogger(RoflThreadLocal.class.getName());
+    private static final ThreadLocal<Stack> threadLocalStack = ThreadLocal.withInitial(Stack::new);
+
+    private RoflThreadLocal() {}
+
+    private static final class Stack {
+        public Frame head = Frame.DEFAULT;
+        public boolean override = false;
+    }
+
+    private static final class Frame {
+        private static final Frame DEFAULT = new Frame();
+        final Rofl value;
+        final Frame prev;
+
+        private Frame() {
+            this.value = Rofl.NONE;
+            this.prev = this;
+        }
+
+        Frame(Rofl value, Frame prev) {
+            this.value = value;
+            this.prev = prev;
+        }
+    }
+
+    public static SimplyCloseable override() {
+        Stack info = threadLocalStack.get();
+        info.override = true;
+        return () -> info.override = false;
+    }
+
+    public static void push(Rofl rofl) {
+        final Stack info = threadLocalStack.get();
+        if (LOGGER.isLoggable(Level.FINER))
+            LOGGER.finer(String.format("ROFL thread local version pushed onto stack: %s", rofl));
+        info.head = new Frame(rofl, info.head);
+    }
+
+    public static Rofl get() {
+        final Stack info = threadLocalStack.get();
+        final boolean override = info.override;
+        final Rofl rofl = (override) ? null : info.head.value;
+        if (LOGGER.isLoggable(Level.FINER))
+            LOGGER.finer(String.format("ROFL thread local version retrieved: %s, override is %b", rofl, override));
+        return rofl;
+    }
+
+    public static Rofl pop() {
+        final Stack info = threadLocalStack.get();
+        final Rofl rofl = info.head.value;
+        if (LOGGER.isLoggable(Level.FINER))
+            LOGGER.finer(String.format("YASF thread local version popped from stack: %s", rofl));
+        info.head = info.head.prev;
+        return rofl;
+    }
+
+    public static void reset() {
+        if (LOGGER.isLoggable(Level.FINER))
+            LOGGER.finer("YASF thread local stack reset");
+        threadLocalStack.remove();
+    }
+}

--- a/yoko-verify/src/test/java-testify/org/apache/yoko/util/rofl/RoflTest.java
+++ b/yoko-verify/src/test/java-testify/org/apache/yoko/util/rofl/RoflTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an \"AS IS\" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.yoko.util.rofl;
+
+import acme.RemoteFunction;
+import org.junit.jupiter.api.Test;
+import org.omg.IOP.ServiceContext;
+import org.omg.IOP.TaggedComponent;
+import org.omg.PortableInterceptor.ClientRequestInfo;
+import org.omg.PortableInterceptor.ClientRequestInterceptor;
+import org.omg.PortableInterceptor.IORInfo;
+import org.omg.PortableInterceptor.ServerRequestInfo;
+import org.omg.PortableInterceptor.ServerRequestInterceptor;
+import testify.hex.HexBuilder;
+import testify.hex.HexParser;
+import testify.iiop.TestClientRequestInterceptor;
+import testify.iiop.TestIORInterceptor;
+import testify.iiop.TestIORInterceptor_3_0;
+import testify.iiop.TestServerRequestInterceptor;
+import testify.iiop.annotation.ConfigureOrb;
+import testify.iiop.annotation.ConfigureOrb.UseWithOrb;
+import testify.iiop.annotation.ConfigureServer;
+import testify.iiop.annotation.ConfigureServer.RemoteImpl;
+
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.rmi.RemoteException;
+import java.util.Objects;
+
+import static org.apache.yoko.util.rofl.Rofl.RemoteOrb.IBM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static testify.hex.HexParser.HEX_STRING;
+import static testify.iiop.annotation.ConfigureOrb.OrbId.CLIENT_ORB;
+import static testify.iiop.annotation.ConfigureOrb.OrbId.SERVER_ORB;
+
+@ConfigureServer
+public class RoflTest {
+    @UseWithOrb({CLIENT_ORB, SERVER_ORB})
+    public static class AddIbmOrbServiceContext implements TestClientRequestInterceptor, TestIORInterceptor {
+        public static final byte[] PAYLOAD = HEX_STRING.parse("00BD001118000000");
+        private final TaggedComponent TC = new TaggedComponent(IBM.tagComponentId, PAYLOAD);
+        private final ServiceContext SC = new ServiceContext(IBM.serviceContextId, PAYLOAD);
+        public void send_request(ClientRequestInfo ri) { ri.add_request_service_context(SC, true); }
+        public void establish_components(IORInfo info) { info.add_ior_component(TC); }
+    }
+
+    public static final class Message implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private final String text;
+        public Message(String text) { this.text = text; }
+        private void readObject(ObjectInputStream in) throws Exception {
+            // Yasf is only set when writing out.
+            // All options default when reading in,
+            // so the thread should have Yasf set to null.
+            assertEquals(Rofl.NONE, RoflThreadLocal.get());
+            in.defaultReadObject();
+        }
+        private void writeObject(ObjectOutputStream out) throws Exception {
+            // Since we are marshalling to another Yoko ORB,
+            // Yasf options should be set when writing out.
+            assertEquals(IBM, RoflThreadLocal.get().type());
+            out.defaultWriteObject();
+        }
+        public boolean equals(Object o) { return o instanceof Message && Objects.equals(text, ((Message) o).text); }
+        public int hashCode() { return Objects.hashCode(text); }
+        public String toString() { return String.format("MessageImpl[%s]", text); }
+    }
+
+    interface Echo extends RemoteFunction<Message, Message>{}
+
+    @RemoteImpl
+    public static final Echo REMOTE = m -> m;
+
+    @Test
+    public void sendMessage(Echo stub) throws RemoteException {
+        Message m1 = new Message("Hello, world!");
+        Message m2 = stub.apply(m1);
+        assertEquals(m1, m2);
+    }
+}


### PR DESCRIPTION
- **test: unmarshal Dates w/ or w/o write object flag**
- **TFW: HexBuilder raw byte[] and dump support**
- **feat: add ROFL detection**
- **test: unmarshal Date like Java 8**
- **feat: marshal Date like Java 8**
