### PR TITLE
Fix policy type value

### DIFF
--- a/yoko-core/src/main/java/org/apache/yoko/orb/OB/ReplyTimeoutPolicy_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OB/ReplyTimeoutPolicy_impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 IBM Corporation and others.
+ * Copyright 2026 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ public final class ReplyTimeoutPolicy_impl extends LocalObject implements ReplyT
     }
 
     public int policy_type() {
-        return REQUEST_TIMEOUT_POLICY_ID.value;
+        return REPLY_TIMEOUT_POLICY_ID.value;
     }
 
     public Policy copy() {

--- a/yoko-verify/src/test/java-testify/org/apache/yoko/orb/OB/TestReplyTimeout.java
+++ b/yoko-verify/src/test/java-testify/org/apache/yoko/orb/OB/TestReplyTimeout.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an \"AS IS\" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.yoko.orb.OB;
+
+import acme.Echo;
+import org.junit.jupiter.api.Test;
+import org.omg.CORBA.TIMEOUT;
+import testify.iiop.annotation.ConfigureOrb;
+import testify.iiop.annotation.ConfigureServer;
+import testify.iiop.annotation.ConfigureServer.RemoteImpl;
+import testify.iiop.annotation.ConfigureServer.RemoteStub;
+
+import java.rmi.RemoteException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static testify.util.Assertions.assertThrows;
+
+// server orb should time out any reply after 2 ms
+@ConfigureServer(serverOrb = @ConfigureOrb(props = "yoko.orb.policy.reply_timeout=2"))
+public class TestReplyTimeout {
+    @RemoteImpl // wait 5 seconds then return
+    public static final Echo wait = s -> { assertDoesNotThrow(() -> Thread.sleep(5000)); return s; };
+    @RemoteStub
+    public static Echo stub;
+
+    @Test
+    void testReplyTimeout() throws Exception {
+        assertThrows(RemoteException.class, () -> stub.echo("Should actually wait until timeout"), TIMEOUT.class);
+    }
+}


### PR DESCRIPTION
Incorrect value results in ClassCastException

```
Caused by: java.lang.ClassCastException: org.apache.yoko.orb.OB.ReplyTimeoutPolicy_impl incompatible with org.apache.yoko.orb.OB.RequestTimeoutPolicy
	at org.apache.yoko.orb.OB.RefCountPolicyList.getRequestTimeout(RefCountPolicyList.java:222)
	at org.apache.yoko.orb.OB.RefCountPolicyList.<init>(RefCountPolicyList.java:476)
	at org.apache.yoko.orb.CORBA.Delegate.<init>(Delegate.java:591)
	at org.apache.yoko.orb.OB.ObjectFactory.createObject(ObjectFactory.java:69)
	at org.apache.yoko.orb.OBPortableInterceptor.TransientORT_impl.makeObject(TransientORT_impl.java:110)
	at org.apache.yoko.orb.OBPortableInterceptor.TransientORT_impl.make_object(TransientORT_impl.java:133)
	at org.apache.yoko.orb.OBPortableServer.POA_impl.id_to_reference(POA_impl.java:1022)
	at org.apache.yoko.rmi.impl.ValueHandlerImpl.getRunTimeCodeBase(ValueHandlerImpl.java:174)
	at org.apache.yoko.orb.OB.SendingContextRuntimes.<clinit>(SendingContextRuntimes.java:30)
	... 49 more
```