### PR TITLE
build: add createLibsSymlinks task for jar file management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -314,3 +314,64 @@ task testReport (type: TestReport) {
     def projectsWithTests = subprojects.findAll { it.tasks.findByName('test') != null }
     testResults.from = projectsWithResults.test
 }
+
+
+task createLibsSymlinks {
+    description = 'Creates symbolic links to jar files in the libs directory'
+    group = 'build'
+
+    def targetProjects = [
+        ':yoko-core',
+        ':yoko-spec-corba',
+        ':yoko-rmi-impl',
+        ':yoko-rmi-spec',
+        ':yoko-util',
+        ':yoko-osgi'
+    ]
+
+    // Depend on jar tasks of all target projects
+    targetProjects.each { projectPath ->
+        dependsOn "${projectPath}:jar"
+    }
+
+    doLast {
+        def libsDir = file("${projectDir}/libs")
+
+        // Create libs directory if it doesn't exist
+        if (!libsDir.exists()) {
+            libsDir.mkdirs()
+            println "Created directory: ${libsDir}"
+        }
+
+        // Clean out existing symbolic links
+        libsDir.listFiles().each { file ->
+            if (java.nio.file.Files.isSymbolicLink(file.toPath())) {
+                file.delete()
+                println "Removed existing symlink: ${file.name}"
+            }
+        }
+
+        // Create symbolic links for each project's jar
+        targetProjects.each { projectPath ->
+            def subproject = project(projectPath)
+            def jarTask = subproject.tasks.jar
+            def jarFile = jarTask.archiveFile.get().asFile
+
+            if (jarFile.exists()) {
+                // Use simple name without version info
+                def projectName = subproject.name
+                def linkFile = new File(libsDir, "${projectName}.jar")
+
+                // Create symbolic link using relative path
+                def relativePath = libsDir.toPath().relativize(jarFile.toPath())
+                java.nio.file.Files.createSymbolicLink(
+                    linkFile.toPath(),
+                    relativePath
+                )
+                println "Created symlink: ${linkFile.name} -> ${relativePath}"
+            } else {
+                println "Warning: JAR file not found: ${jarFile}"
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ buildscript {
 plugins {
   id "biz.aQute.bnd.builder" version "6.4.0" apply false
   id "com.dorongold.task-tree" version "2.1.1"
+  id "base"
 }
 
 ext {
@@ -316,8 +317,8 @@ task testReport (type: TestReport) {
 }
 
 
-task createLibsSymlinks {
-    description = 'Creates symbolic links to jar files in the libs directory'
+task createBuildLibSymlinks {
+    description = 'Creates symbolic links to jar files in the build/lib directory'
     group = 'build'
 
     def targetProjects = [
@@ -334,17 +335,20 @@ task createLibsSymlinks {
         dependsOn "${projectPath}:jar"
     }
 
-    doLast {
-        def libsDir = file("${projectDir}/libs")
+    // Register output directory so gradle clean removes it
+    outputs.dir("${buildDir}/lib")
 
-        // Create libs directory if it doesn't exist
-        if (!libsDir.exists()) {
-            libsDir.mkdirs()
-            println "Created directory: ${libsDir}"
+    doLast {
+        def libDir = file("${buildDir}/lib")
+
+        // Create lib directory if it doesn't exist
+        if (!libDir.exists()) {
+            libDir.mkdirs()
+            println "Created directory: ${libDir}"
         }
 
         // Clean out existing symbolic links
-        libsDir.listFiles().each { file ->
+        libDir.listFiles().each { file ->
             if (java.nio.file.Files.isSymbolicLink(file.toPath())) {
                 file.delete()
                 println "Removed existing symlink: ${file.name}"
@@ -360,10 +364,10 @@ task createLibsSymlinks {
             if (jarFile.exists()) {
                 // Use simple name without version info
                 def projectName = subproject.name
-                def linkFile = new File(libsDir, "${projectName}.jar")
+                def linkFile = new File(libDir, "${projectName}.jar")
 
                 // Create symbolic link using relative path
-                def relativePath = libsDir.toPath().relativize(jarFile.toPath())
+                def relativePath = libDir.toPath().relativize(jarFile.toPath())
                 java.nio.file.Files.createSymbolicLink(
                     linkFile.toPath(),
                     relativePath


### PR DESCRIPTION
Add a new Gradle task that creates symbolic links to jar files in the libs directory for easier access to built artifacts. The task:
- Creates symlinks for core Yoko modules (yoko-core, yoko-spec-corba, yoko-rmi-impl, yoko-rmi-spec, yoko-util, yoko-osgi)
- Automatically cleans existing symlinks before creating new ones
- Uses relative paths for portability
- Depends on jar tasks to ensure artifacts are built first
