### PR TITLE
build: add Gradle version consistency validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 IBM Corporation and others.
+# Copyright 2026 IBM Corporation and others.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,3 +38,10 @@ repos:
         entry: scripts/check-copyright.sh -s
         language: script
         pass_filenames: false
+      - id: check-gradle-version
+        name: Check Gradle version consistency
+        description: Ensures .sdkmanrc and gradle-wrapper.properties have matching Gradle versions
+        entry: ./gradlew help --quiet
+        language: system
+        pass_filenames: false
+        files: '^(\.sdkmanrc|gradle/wrapper/gradle-wrapper\.properties)$'

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,55 @@ wrapper {
     distributionType = Wrapper.DistributionType.ALL
 }
 
+// Validate that .sdkmanrc Gradle version matches wrapper version
+def validateGradleVersions() {
+    def sdkmanrcFile = file('.sdkmanrc')
+    def wrapperPropsFile = file('gradle/wrapper/gradle-wrapper.properties')
+
+    if (!sdkmanrcFile.exists()) {
+        logger.warn("Warning: .sdkmanrc file not found")
+        return
+    }
+
+    if (!wrapperPropsFile.exists()) {
+        throw new GradleException("gradle-wrapper.properties not found")
+    }
+
+    // Parse .sdkmanrc for gradle version
+    def sdkmanrcVersion = null
+    sdkmanrcFile.eachLine { line ->
+        if (line.trim().startsWith('gradle=')) {
+            sdkmanrcVersion = line.split('=')[1].trim()
+        }
+    }
+
+    // Parse wrapper properties for gradle version
+    def wrapperVersion = null
+    wrapperPropsFile.eachLine { line ->
+        if (line.trim().startsWith('distributionUrl=')) {
+            def matcher = (line =~ /gradle-(\d+\.\d+(?:\.\d+)?)-/)
+            if (matcher.find()) {
+                wrapperVersion = matcher.group(1)
+            }
+        }
+    }
+
+    if (sdkmanrcVersion && wrapperVersion) {
+        if (sdkmanrcVersion != wrapperVersion) {
+            throw new GradleException(
+                "Gradle version mismatch!\n" +
+                "  .sdkmanrc:                    gradle=${sdkmanrcVersion}\n" +
+                "  gradle-wrapper.properties:    gradle-${wrapperVersion}\n" +
+                "Please update both files to use the same Gradle version."
+            )
+        }
+        logger.quiet("✓ Gradle version validated: ${wrapperVersion}")
+    }
+}
+
+// Run validation during configuration phase
+validateGradleVersions()
+
 // Apply release configuration
 apply from: 'build-release.gradle'
 


### PR DESCRIPTION
Add validation to ensure .sdkmanrc and gradle-wrapper.properties maintain matching Gradle versions:
- Add pre-commit hook to check version consistency
- Add build-time validation that fails on version mismatch
- Provide clear error messages when versions don't match

Co-authored-by: IBM Bob 1.0.1
