### PR TITLE
fix/enum fvd accuracy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -468,3 +468,6 @@ task createBuildLibSymlinks {
         }
     }
 }
+
+// Make createBuildLibSymlinks run at the end of build
+build.finalizedBy createBuildLibSymlinks

--- a/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/EnumDescriptor.java
+++ b/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/EnumDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 IBM Corporation and others.
+ * Copyright 2026 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,7 @@ package org.apache.yoko.rmi.impl;
 
 import java.io.IOException;
 import java.io.Serializable;
-
-import static org.apache.yoko.util.yasf.Yasf.ENUM_FIXED;
+import java.util.Arrays;
 
 class EnumDescriptor extends ValueDescriptor {
     public EnumDescriptor(Class<?> type, TypeRepository repo) {
@@ -37,28 +36,9 @@ class EnumDescriptor extends ValueDescriptor {
         return true;
     }
 
-    private FieldDescriptor nameField = null;
-    private FieldDescriptor ordinalField = null;
-
     @Override
-    public final void init() {
-        super.init();
-        // Avoid doing anything that would cause the calculated classHash to change
-        for (FieldDescriptor f: _fields) {
-            if (f.java_name.equals("name")) {
-                nameField = f;
-            } else if (f.java_name.equals("ordinal")) {
-                ordinalField = f;
-            }
-        }
-    }
-
-    @Override
-    protected void defaultWriteValue(ObjectWriter writer, Serializable val) throws IOException {
-        if (ENUM_FIXED.isUnsupported()) {
-            // talking to an old yoko that expects an ordinal field to be written
-            ordinalField.write(writer, val);
-        }
-        nameField.write(writer, val);
+    protected boolean includeField(java.lang.reflect.Field f) {
+        // Only include the name field, exclude ordinal to match what's marshalled
+        return "name".equals(f.getName());
     }
 }

--- a/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/EnumSubclassDescriptor.java
+++ b/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/EnumSubclassDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 IBM Corporation and others.
+ * Copyright 2026 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.apache.yoko.rmi.impl;
 
 import org.omg.CORBA.portable.IndirectionException;
 import org.omg.CORBA.portable.InputStream;
+import org.omg.CORBA.ValueMember;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -93,5 +94,12 @@ class EnumSubclassDescriptor extends ValueDescriptor {
     public final Serializable writeReplace(Serializable val) {
         // Never allow the honoring of writeReplace on an Enum subclass
         return val;
+    }
+
+    @Override
+    protected boolean includeField(java.lang.reflect.Field f) {
+        // Enum subclasses have no fields of their own - they delegate to the parent enum
+        // Exclude all fields so _fields is empty, which makes genValueMembers() return empty array
+        return false;
     }
 }

--- a/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/ValueDescriptor.java
+++ b/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/ValueDescriptor.java
@@ -149,6 +149,25 @@ class ValueDescriptor extends TypeDescriptor {
         return (serialForm != null) ? serialForm.getSerialVersionUID() : 0L;
     }
 
+    /**
+     * Filters out static and transient fields. This is the base filter that always applies.
+     */
+    private final boolean isSerializableField(Field f) {
+        int mod = f.getModifiers();
+        return !Modifier.isStatic(mod) && !Modifier.isTransient(mod);
+    }
+
+    /**
+     * Additional filter for fields. Subclasses can override to exclude specific fields
+     * from _fields, FVD, and hash calculation (e.g., EnumDescriptor excludes the ordinal field).
+     *
+     * @param f the field to check
+     * @return true if the field should be included, false otherwise
+     */
+    protected boolean includeField(Field f) {
+        return true;
+    }
+
     public void init() {
         try {
             init0();
@@ -298,23 +317,13 @@ class ValueDescriptor extends TypeDescriptor {
                         _fields = new FieldDescriptor[0];
 
                     } else {
-                        List<FieldDescriptor> flist = new ArrayList<>();
-
-                        for (Field f : ff) {
-                            int mod = f.getModifiers();
-                            if (Modifier.isStatic(mod) || Modifier.isTransient(mod)) {
-                                continue;
-                            }
-
-                            f.setAccessible(true);
-                            FieldDescriptor fd = FieldDescriptor.get(f, repo);
-                            flist.add(fd);
-                        }
-
-                        _fields = new FieldDescriptor[flist.size()];
-                        _fields = flist.toArray(_fields);
-
-                        Arrays.sort(_fields);
+                        _fields = Arrays.stream(ff)
+                            .filter(ValueDescriptor.this::isSerializableField)
+                            .filter(ValueDescriptor.this::includeField)
+                            .peek(f -> f.setAccessible(true))
+                            .map(f -> FieldDescriptor.get(f, repo))
+                            .sorted()
+                            .toArray(FieldDescriptor[]::new);
                     }
                 } else {
                     _fields = new FieldDescriptor[serial_persistent_fields.length];

--- a/yoko-util/src/main/java/org/apache/yoko/util/yasf/Yasf.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/yasf/Yasf.java
@@ -36,9 +36,10 @@ import static org.apache.yoko.util.Collectors.toUnmodifiableEnumSet;
  * </ul>
  */
 public enum Yasf {
-    ENUM_FIXED(0),
+    ENUM_FIX_1(0),
     NON_SERIALIZABLE_FIELD_IS_ABSTRACT_VALUE(1),
     WRITE_UTF8_AS_UTF8(2),
+    ENUM_TRUE_HASH_AND_FVD(3),
     ;
     // TODO - Get the OMG to assign this value to Yoko
     public static final int TAG_YOKO_AUXILIARY_STREAM_FORMAT = 0xeeeeeeee;

--- a/yoko-verify/src/test/java-testify/org/apache/yoko/JavaValueNullFieldsTest.java
+++ b/yoko-verify/src/test/java-testify/org/apache/yoko/JavaValueNullFieldsTest.java
@@ -35,7 +35,7 @@ import testify.annotation.Logging;
 import java.io.Serializable;
 import java.util.EnumSet;
 
-import static org.apache.yoko.util.yasf.Yasf.ENUM_FIXED;
+import static org.apache.yoko.util.yasf.Yasf.ENUM_FIX_1;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -49,7 +49,7 @@ import static testify.matchers.ByteArrayMatchers.matchesHex;
  * were not supported in CDR streams
  */
 class JavaValueNullFieldsTest {
-    private static final EnumSet<Yasf> OLD_STYLE = EnumSet.of(ENUM_FIXED);
+    private static final EnumSet<Yasf> OLD_STYLE = EnumSet.of(ENUM_FIX_1);
 
     YokoOutputStream out;
     byte[] data;


### PR DESCRIPTION
- **fix(rmi): ensure enum FVD accurately reflects marshalled fields**
- **fix(rmi): ensure enum subclass FVD accurately reflects no fields**
