### PR TITLE
feat(yoko-util): add thread-safe lazy initialization utility

### DIFF
--- a/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyInitializedField.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyInitializedField.java
@@ -22,6 +22,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A thread-safe lazily initialized field using atomic function pointer swapping.
  * <p>
@@ -88,7 +90,7 @@ public class LazyInitializedField<T> {
      * @param initializer the supplier that will compute the value on first access
      */
     public LazyInitializedField(Supplier<T> initializer) {
-        this.initializer = initializer;
+        this.initializer = requireNonNull(initializer, "initializer must not be null");
         this.functionPointer = new AtomicReference<>(initializationFunctionRef);
     }
 
@@ -157,7 +159,7 @@ public class LazyInitializedField<T> {
 
             LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " completed initialization");
             return result;
-        } catch (Exception e) {
+        } catch (Throwable e) {
             LOGGER.warning(() -> "Thread " + Thread.currentThread().getName() + " failed initialization, resetting for retry");
             functionPointer.set(initializationFunctionRef);
             throw e;

--- a/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyInitializedField.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyInitializedField.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.yoko.util.concurrent;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+
+/**
+ * A thread-safe lazily initialized field using atomic function pointer swapping.
+ * <p>
+ * This implementation uses a sophisticated lock-free pattern where:
+ * <ol>
+ *   <li>The atomic function pointer initially points to an initialization function</li>
+ *   <li>The first thread to call get() atomically swaps to a "waiting" function</li>
+ *   <li>If the swap succeeds, that thread performs initialization</li>
+ *   <li>If the swap fails, other threads wait on a latch</li>
+ *   <li>After initialization, the pointer is swapped to a simple getter function</li>
+ *   <li>The latch is released, allowing waiting threads to proceed</li>
+ * </ol>
+ *
+ * @param <T> the type of the lazily initialized value
+ */
+public class LazyInitializedField<T> {
+    private static final Logger LOGGER = Logger.getLogger(LazyInitializedField.class.getName());
+
+    /**
+     * Marker interface for the getter function to enable instanceof checks.
+     */
+    private interface Getter<T> extends Supplier<T> {
+    }
+
+    /**
+     * Waiting function that carries its own latch for coordinating threads.
+     */
+    private class Waiter implements Supplier<T> {
+        public final CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        public T get() {
+            LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " waiting for initialization");
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting for initialization", e);
+            }
+            LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " resuming after initialization");
+            return functionPointer.get().get();
+        }
+    }
+
+    /**
+     * Atomic reference to the current function pointer.
+     * This will be swapped between initialization, waiting, and getter functions.
+     */
+    private final AtomicReference<Supplier<T>> functionPointer;
+
+    /**
+     * The supplier that performs the actual lazy initialization.
+     */
+    private final Supplier<T> initializer;
+
+    /**
+     * Reference to the initialization function for use in CAS operation.
+     */
+    private final Supplier<T> initializationFunctionRef = this::initializationFunction;
+
+    /**
+     * Creates a new lazily initialized field.
+     *
+     * @param initializer the supplier that will compute the value on first access
+     */
+    public LazyInitializedField(Supplier<T> initializer) {
+        this.initializer = initializer;
+        this.functionPointer = new AtomicReference<>(initializationFunctionRef);
+    }
+
+    /**
+     * Gets the value, initializing it if necessary.
+     * <p>
+     * This method is thread-safe and ensures that initialization happens exactly once,
+     * even under concurrent access.
+     *
+     * @return the initialized value
+     */
+    public T get() {
+        return functionPointer.get().get();
+    }
+
+    /**
+     * The initialization function - attempts to atomically swap to the waiting function.
+     * <p>
+     * If the swap succeeds, this thread becomes the initializer.
+     * If the swap fails, another thread is already initializing, so wait.
+     *
+     * @return the initialized value
+     */
+    private T initializationFunction() {
+        LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " attempting to initialize");
+
+        Waiter waiter = new Waiter();
+
+        boolean swapSucceeded = functionPointer.compareAndSet(
+                initializationFunctionRef,
+                waiter
+        );
+
+        if (swapSucceeded) {
+            LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " won initialization race");
+            return performInitialization(waiter);
+        } else {
+            LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " lost initialization race, reinvoking");
+            return functionPointer.get().get();
+        }
+    }
+
+
+
+    /**
+     * Performs the actual lazy initialization.
+     * <p>
+     * This method:
+     * <ol>
+     *   <li>Calls the initializer to compute the value</li>
+     *   <li>On success: swaps the function pointer to the getter function</li>
+     *   <li>On failure: resets the function pointer to allow retry</li>
+     *   <li>Releases the latch to unblock waiting threads</li>
+     * </ol>
+     *
+     * @param waiter the waiter function that holds the latch
+     * @return the initialized value
+     */
+    private T performInitialization(Waiter waiter) {
+        try {
+            LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " performing initialization");
+
+            T result = initializer.get();
+            Getter<T> getter = () -> result;
+            functionPointer.set(getter);
+
+            LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " completed initialization");
+            return result;
+        } catch (Exception e) {
+            LOGGER.warning(() -> "Thread " + Thread.currentThread().getName() + " failed initialization, resetting for retry");
+            functionPointer.set(initializationFunctionRef);
+            throw e;
+        } finally {
+            waiter.latch.countDown();
+            LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " released initialization latch");
+        }
+    }
+
+    /**
+     * Checks if the field has been initialized.
+     *
+     * @return true if initialization has completed, false otherwise
+     */
+    public boolean isInitialized() {
+        return functionPointer.get() instanceof Getter;
+    }
+}

--- a/yoko-util/src/test/java/org/apache/yoko/util/concurrent/LazyInitializedFieldTest.java
+++ b/yoko-util/src/test/java/org/apache/yoko/util/concurrent/LazyInitializedFieldTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.yoko.util.concurrent;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.RepeatedTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link LazyInitializedField}.
+ */
+class LazyInitializedFieldTest {
+
+    @Test
+    void testBasicInitialization() {
+        AtomicInteger initCount = new AtomicInteger(0);
+        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+            initCount.incrementAndGet();
+            return "initialized";
+        });
+
+        assertFalse(field.isInitialized(), "Field should not be initialized initially");
+
+        String value = field.get();
+        assertEquals("initialized", value, "Should return initialized value");
+        assertEquals(1, initCount.get(), "Initializer should be called exactly once");
+        assertTrue(field.isInitialized(), "Field should be initialized after first get");
+
+        // Second call should return cached value without re-initialization
+        String value2 = field.get();
+        assertEquals("initialized", value2, "Should return same value");
+        assertEquals(1, initCount.get(), "Initializer should still be called only once");
+    }
+
+    @Test
+    void testConcurrentInitialization() throws InterruptedException {
+        AtomicInteger initCount = new AtomicInteger(0);
+        AtomicInteger maxConcurrentInits = new AtomicInteger(0);
+        AtomicInteger currentConcurrentInits = new AtomicInteger(0);
+
+        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+            initCount.incrementAndGet();
+            int concurrent = currentConcurrentInits.incrementAndGet();
+            maxConcurrentInits.updateAndGet(max -> Math.max(max, concurrent));
+
+            // Simulate some work
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+
+            currentConcurrentInits.decrementAndGet();
+            return "initialized";
+        });
+
+        int threadCount = 10;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    // Wait for all threads to be ready
+                    startLatch.await();
+
+                    // All threads try to get the value simultaneously
+                    String value = field.get();
+                    assertEquals("initialized", value, "All threads should get the same value");
+                } catch (Throwable t) {
+                    error.set(t);
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        // Release all threads at once
+        startLatch.countDown();
+
+        // Wait for all threads to complete
+        assertTrue(doneLatch.await(10, TimeUnit.SECONDS), "All threads should complete");
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS), "Executor should terminate");
+
+        assertNull(error.get(), "No errors should occur");
+        assertEquals(1, initCount.get(), "Initializer should be called exactly once despite concurrent access");
+        assertEquals(1, maxConcurrentInits.get(), "Only one thread should be initializing at a time");
+    }
+
+    @RepeatedTest(10)
+    void testHighContentionInitialization() throws InterruptedException {
+        AtomicInteger initCount = new AtomicInteger(0);
+
+        LazyInitializedField<Integer> field = new LazyInitializedField<>(() -> {
+            int count = initCount.incrementAndGet();
+            // Simulate expensive initialization
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return count;
+        });
+
+        int threadCount = 50;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    Integer value = field.get();
+                    assertEquals(1, value.intValue(), "All threads should get value 1");
+                    successCount.incrementAndGet();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertTrue(doneLatch.await(10, TimeUnit.SECONDS), "All threads should complete");
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS), "Executor should terminate");
+
+        assertEquals(threadCount, successCount.get(), "All threads should succeed");
+        assertEquals(1, initCount.get(), "Initializer should be called exactly once");
+    }
+
+    @Test
+    void testInitializationWithException() {
+        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+            throw new RuntimeException("Initialization failed");
+        });
+
+        assertThrows(RuntimeException.class, field::get, "Should propagate initialization exception");
+    }
+
+    @Test
+    void testInitializationWithExceptionRetry() {
+        AtomicInteger attemptCount = new AtomicInteger(0);
+        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+            int attempt = attemptCount.incrementAndGet();
+            if (attempt == 1) {
+                throw new RuntimeException("First attempt failed");
+            }
+            return "success-" + attempt;
+        });
+
+        // First attempt should fail
+        assertThrows(RuntimeException.class, field::get, "First attempt should throw exception");
+        assertFalse(field.isInitialized(), "Field should not be initialized after exception");
+
+        // Second attempt should succeed
+        String value = field.get();
+        assertEquals("success-2", value, "Second attempt should succeed");
+        assertTrue(field.isInitialized(), "Field should be initialized after successful retry");
+        assertEquals(2, attemptCount.get(), "Should have attempted twice");
+
+        // Subsequent calls should return cached value
+        assertEquals("success-2", field.get(), "Should return cached value");
+        assertEquals(2, attemptCount.get(), "Should not retry after success");
+    }
+
+    @Test
+    void testMultipleInstances() {
+        AtomicInteger initCount = new AtomicInteger(0);
+        Supplier<String> supplier = () -> {
+            int count = initCount.incrementAndGet();
+            return "initialized-" + count;
+        };
+
+        LazyInitializedField<String> field1 = new LazyInitializedField<>(supplier);
+        assertEquals("initialized-1", field1.get());
+        assertTrue(field1.isInitialized());
+
+        LazyInitializedField<String> field2 = new LazyInitializedField<>(supplier);
+        assertEquals("initialized-2", field2.get());
+        assertTrue(field2.isInitialized());
+
+        // Verify each field maintains its own value
+        assertEquals("initialized-1", field1.get());
+        assertEquals("initialized-2", field2.get());
+        assertEquals(2, initCount.get(), "Initializer should be called once per field");
+    }
+
+    @Test
+    void testNullValue() {
+        LazyInitializedField<String> field = new LazyInitializedField<>(() -> null);
+
+        assertNull(field.get(), "Should support null values");
+        assertTrue(field.isInitialized(), "Field should be initialized even with null value");
+
+        // Second call should still return null without re-initialization
+        assertNull(field.get(), "Should return null on subsequent calls");
+    }
+
+    @Test
+    void testComplexObject() {
+        class ComplexObject {
+            final String name;
+            final int value;
+
+            ComplexObject(String name, int value) {
+                this.name = name;
+                this.value = value;
+            }
+        }
+
+        AtomicInteger counter = new AtomicInteger(0);
+        LazyInitializedField<ComplexObject> field = new LazyInitializedField<>(() -> {
+            counter.incrementAndGet();
+            return new ComplexObject("test", 42);
+        });
+
+        ComplexObject obj1 = field.get();
+        ComplexObject obj2 = field.get();
+
+        assertSame(obj1, obj2, "Should return the same instance");
+        assertEquals("test", obj1.name);
+        assertEquals(42, obj1.value);
+        assertEquals(1, counter.get(), "Should initialize only once");
+    }
+
+    @Test
+    void testSequentialAccess() {
+        AtomicInteger initCount = new AtomicInteger(0);
+        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+            initCount.incrementAndGet();
+            return "value";
+        });
+
+        // Multiple sequential accesses
+        for (int i = 0; i < 100; i++) {
+            assertEquals("value", field.get());
+        }
+
+        assertEquals(1, initCount.get(), "Should initialize only once despite many accesses");
+    }
+}

--- a/yoko-util/src/test/java/org/apache/yoko/util/concurrent/LazyInitializedFieldTest.java
+++ b/yoko-util/src/test/java/org/apache/yoko/util/concurrent/LazyInitializedFieldTest.java
@@ -28,12 +28,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
+import static java.util.stream.IntStream.range;
 import static org.junit.jupiter.api.Assertions.*;
 
-/**
- * Tests for {@link LazyInitializedField}.
- */
 class LazyInitializedFieldTest {
+    private static final int INITIALIZATION_DELAY_MS = 50;
+    private static final int EXPENSIVE_INITIALIZATION_DELAY_MS = 10;
+    private static final int CONCURRENT_THREAD_COUNT = 10;
+    private static final int HIGH_CONTENTION_THREAD_COUNT = 50;
+    private static final int TEST_TIMEOUT_SECONDS = 10;
+    private static final int EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS = 5;
+    private static final int SEQUENTIAL_ACCESS_COUNT = 100;
 
     @Test
     void testBasicInitialization() {
@@ -69,7 +74,7 @@ class LazyInitializedFieldTest {
 
             // Simulate some work
             try {
-                Thread.sleep(50);
+                Thread.sleep(INITIALIZATION_DELAY_MS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
@@ -78,14 +83,13 @@ class LazyInitializedFieldTest {
             return "initialized";
         });
 
-        int threadCount = 10;
-        CountDownLatch startLatch = new CountDownLatch(1);
-        CountDownLatch doneLatch = new CountDownLatch(threadCount);
-        AtomicReference<Throwable> error = new AtomicReference<>();
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CountDownLatch doneLatch = new CountDownLatch(CONCURRENT_THREAD_COUNT);
+        final AtomicReference<Throwable> error = new AtomicReference<>();
 
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(CONCURRENT_THREAD_COUNT);
 
-        for (int i = 0; i < threadCount; i++) {
+        range(0, CONCURRENT_THREAD_COUNT).forEach(i -> {
             executor.submit(() -> {
                 try {
                     // Wait for all threads to be ready
@@ -100,16 +104,16 @@ class LazyInitializedFieldTest {
                     doneLatch.countDown();
                 }
             });
-        }
+        });
 
         // Release all threads at once
         startLatch.countDown();
 
         // Wait for all threads to complete
-        assertTrue(doneLatch.await(10, TimeUnit.SECONDS), "All threads should complete");
+        assertTrue(doneLatch.await(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS), "All threads should complete");
 
         executor.shutdown();
-        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS), "Executor should terminate");
+        assertTrue(executor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS), "Executor should terminate");
 
         assertNull(error.get(), "No errors should occur");
         assertEquals(1, initCount.get(), "Initializer should be called exactly once despite concurrent access");
@@ -124,21 +128,20 @@ class LazyInitializedFieldTest {
             int count = initCount.incrementAndGet();
             // Simulate expensive initialization
             try {
-                Thread.sleep(10);
+                Thread.sleep(EXPENSIVE_INITIALIZATION_DELAY_MS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
             return count;
         });
 
-        int threadCount = 50;
         CountDownLatch startLatch = new CountDownLatch(1);
-        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+        CountDownLatch doneLatch = new CountDownLatch(HIGH_CONTENTION_THREAD_COUNT);
         AtomicInteger successCount = new AtomicInteger(0);
 
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        ExecutorService executor = Executors.newFixedThreadPool(HIGH_CONTENTION_THREAD_COUNT);
 
-        for (int i = 0; i < threadCount; i++) {
+        for (int i = 0; i < HIGH_CONTENTION_THREAD_COUNT; i++) {
             executor.submit(() -> {
                 try {
                     startLatch.await();
@@ -154,12 +157,12 @@ class LazyInitializedFieldTest {
         }
 
         startLatch.countDown();
-        assertTrue(doneLatch.await(10, TimeUnit.SECONDS), "All threads should complete");
+        assertTrue(doneLatch.await(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS), "All threads should complete");
 
         executor.shutdown();
-        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS), "Executor should terminate");
+        assertTrue(executor.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS), "Executor should terminate");
 
-        assertEquals(threadCount, successCount.get(), "All threads should succeed");
+        assertEquals(HIGH_CONTENTION_THREAD_COUNT, successCount.get(), "All threads should succeed");
         assertEquals(1, initCount.get(), "Initializer should be called exactly once");
     }
 
@@ -267,7 +270,7 @@ class LazyInitializedFieldTest {
         });
 
         // Multiple sequential accesses
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < SEQUENTIAL_ACCESS_COUNT; i++) {
             assertEquals("value", field.get());
         }
 


### PR DESCRIPTION
Add LazyInitializedField<T> class that provides lock-free lazy initialization
using atomic function pointer swapping pattern.

Features:
- Thread-safe initialization with exactly-once guarantee
- Lock-free implementation using AtomicReference and CAS operations
- Automatic retry on initialization failure
- Per-waiter CountDownLatch for proper thread coordination
- Closure-based value caching (no separate value field)
- Supplier-based logging for performance

Implementation uses three-state pattern:
1. Initialization function (initial state)
2. Waiter function with latch (during initialization)
3. Getter function with cached value (after initialization)

Includes comprehensive test suite with 18 tests covering:
- Basic initialization and caching
- Concurrent access (10 threads)
- High contention scenarios (50 threads)
- Exception handling and retry
- Null value support
- Complex object handling
