### PR TITLE
feat/enhance lazy initialized field

### DIFF
--- a/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyInitializedField.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyInitializedField.java
@@ -52,6 +52,15 @@ public class LazyInitializedField<T> {
     }
 
     /**
+     * Exception thrown when a thread is interrupted while waiting for initialization.
+     */
+    public static class InitializationInterruptedException extends RuntimeException {
+        private InitializationInterruptedException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    /**
      * Marker interface for the getter function to enable instanceof checks.
      */
     private interface Getter<T> extends Supplier<T> {
@@ -70,7 +79,7 @@ public class LazyInitializedField<T> {
                 latch.await();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw new RuntimeException("Interrupted while waiting for initialization", e);
+                throw new InitializationInterruptedException("Interrupted while waiting for initialization", e);
             }
             LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " resuming after initialization");
             return functionPointer.get().get();
@@ -129,9 +138,14 @@ public class LazyInitializedField<T> {
      * will throw {@link InitializationException} wrapping the original cause. This
      * applies to both the initial call and all subsequent calls, without retrying
      * initialization.
+     * <p>
+     * If a thread is interrupted while waiting for initialization to complete by another
+     * thread, this method will throw {@link InitializationInterruptedException} wrapping
+     * the {@link InterruptedException}.
      *
      * @return the initialized value
      * @throws InitializationException iff initialization failed and retry is not allowed
+     * @throws InitializationInterruptedException if the thread is interrupted while waiting for initialization
      */
     public T get() {
         return functionPointer.get().get();

--- a/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyInitializedField.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyInitializedField.java
@@ -43,6 +43,15 @@ public class LazyInitializedField<T> {
     private static final Logger LOGGER = Logger.getLogger(LazyInitializedField.class.getName());
 
     /**
+     * Exception thrown when lazy initialization fails and retry is not allowed.
+     */
+    public static class InitializationException extends RuntimeException {
+        private InitializationException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    /**
      * Marker interface for the getter function to enable instanceof checks.
      */
     private interface Getter<T> extends Supplier<T> {
@@ -80,17 +89,33 @@ public class LazyInitializedField<T> {
     private final Supplier<T> initializer;
 
     /**
+     * Whether to allow retry on initialization failure.
+     */
+    private final boolean allowRetry;
+
+    /**
      * Reference to the initialization function for use in CAS operation.
      */
     private final Supplier<T> initializationFunctionRef = this::initializationFunction;
 
     /**
-     * Creates a new lazily initialized field.
+     * Creates a new lazily initialized field with retry disabled.
      *
      * @param initializer the supplier that will compute the value on first access
      */
     public LazyInitializedField(Supplier<T> initializer) {
+        this(initializer, false);
+    }
+
+    /**
+     * Creates a new lazily initialized field.
+     *
+     * @param initializer the supplier that will compute the value on first access
+     * @param allowRetry whether to allow retry on initialization failure
+     */
+    public LazyInitializedField(Supplier<T> initializer, boolean allowRetry) {
         this.initializer = requireNonNull(initializer, "initializer must not be null");
+        this.allowRetry = allowRetry;
         this.functionPointer = new AtomicReference<>(initializationFunctionRef);
     }
 
@@ -99,8 +124,14 @@ public class LazyInitializedField<T> {
      * <p>
      * This method is thread-safe and ensures that initialization happens exactly once,
      * even under concurrent access.
+     * <p>
+     * If initialization fails and {@code allowRetry} is {@code false}, this method
+     * will throw {@link InitializationException} wrapping the original cause. This
+     * applies to both the initial call and all subsequent calls, without retrying
+     * initialization.
      *
      * @return the initialized value
+     * @throws InitializationException iff initialization failed and retry is not allowed
      */
     public T get() {
         return functionPointer.get().get();
@@ -166,9 +197,19 @@ public class LazyInitializedField<T> {
             LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " completed initialization");
             return result;
         } catch (Throwable e) {
-            LOGGER.warning(() -> "Thread " + Thread.currentThread().getName() + " failed initialization, resetting for retry");
-            functionPointer.set(initializationFunctionRef);
-            throw e;
+            if (allowRetry) {
+                LOGGER.warning(() -> "Thread " + Thread.currentThread().getName() + " failed initialization, resetting for retry");
+                functionPointer.set(initializationFunctionRef);
+                throw e;
+            } else {
+                LOGGER.warning(() -> "Thread " + Thread.currentThread().getName() + " failed initialization, setting permanent error state");
+                // Store the original cause and create new exception on each call for accurate stack traces
+                Getter<T> errorGetter = () -> {
+                    throw new InitializationException("Initialization failed and retry is not allowed", e);
+                };
+                functionPointer.set(errorGetter);
+                throw new InitializationException("Initialization failed and retry is not allowed", e);
+            }
         } finally {
             waiter.latch.countDown();
             LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " released initialization latch");
@@ -176,11 +217,15 @@ public class LazyInitializedField<T> {
     }
 
     /**
-     * Checks if the field has been initialized.
+     * Checks if initialization has completed.
+     * <p>
+     * Returns {@code true} if initialization succeeded or failed with {@code allowRetry=false}
+     * (permanent error state). Returns {@code false} if not yet attempted or failed with
+     * {@code allowRetry=true} (retry allowed).
      *
-     * @return true if initialization has completed, false otherwise
+     * @return true if initialization completed (success or permanent error), false otherwise
      */
-    public boolean isInitialized() {
+    public boolean isCompleted() {
         return functionPointer.get() instanceof Getter;
     }
 }

--- a/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyInitializedField.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyInitializedField.java
@@ -117,6 +117,12 @@ public class LazyInitializedField<T> {
     private T initializationFunction() {
         LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " attempting to initialize");
 
+        // Check if we're still in initialization state before allocating Waiter
+        if (functionPointer.get() != initializationFunctionRef) {
+            LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " detected initialization already in progress, reinvoking");
+            return functionPointer.get().get();
+        }
+
         Waiter waiter = new Waiter();
 
         boolean swapSucceeded = functionPointer.compareAndSet(

--- a/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyReference.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyReference.java
@@ -61,6 +61,16 @@ public class LazyReference<T> {
     }
 
     /**
+     * Exception thrown when recursive initialization is detected.
+     */
+    public static class RecursiveInitializationException extends IllegalStateException {
+        private RecursiveInitializationException(String threadName) {
+            super("Recursive initialization detected: Thread " + threadName + 
+                  " attempted to call get() while already initializing");
+        }
+    }
+
+    /**
      * Marker interface for the getter function to enable instanceof checks.
      */
     private interface Getter<T> extends Supplier<T> {
@@ -71,17 +81,24 @@ public class LazyReference<T> {
      */
     private class Waiter implements Supplier<T> {
         public final CountDownLatch latch = new CountDownLatch(1);
+        private final Thread initializingThread = Thread.currentThread();
 
         @Override
         public T get() {
-            LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " waiting for initialization");
+            final Thread currentThread = Thread.currentThread();
+            // Detect recursive call from the initializing thread
+            if (initializingThread == currentThread) {
+                throw new RecursiveInitializationException(currentThread.getName());
+            }
+            
+            LOGGER.fine(() -> "Thread " + currentThread.getName() + " waiting for initialization");
             try {
                 latch.await();
             } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+                currentThread.interrupt();
                 throw new InitializationInterruptedException("Interrupted while waiting for initialization", e);
             }
-            LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " resuming after initialization");
+            LOGGER.fine(() -> "Thread " + currentThread.getName() + " resuming after initialization");
             return functionPointer.get().get();
         }
     }
@@ -142,10 +159,16 @@ public class LazyReference<T> {
      * If a thread is interrupted while waiting for initialization to complete by another
      * thread, this method will throw {@link InitializationInterruptedException} wrapping
      * the {@link InterruptedException}.
+     * <p>
+     * If the initializer recursively calls {@code get()} on the same {@code LazyReference}
+     * instance, this method will throw {@link IllegalStateException} wrapping a
+     * {@link RecursiveInitializationException}. This prevents deadlock where the initializing
+     * thread would wait for itself to complete initialization.
      *
      * @return the initialized value
      * @throws InitializationException iff initialization failed and retry is not allowed
      * @throws InitializationInterruptedException if the thread is interrupted while waiting for initialization
+     * @throws IllegalStateException if recursive initialization is detected
      */
     public T get() {
         return functionPointer.get().get();
@@ -210,6 +233,15 @@ public class LazyReference<T> {
 
             LOGGER.fine(() -> "Thread " + Thread.currentThread().getName() + " completed initialization");
             return result;
+        } catch (RecursiveInitializationException e) {
+            // Recursive initialization is a programming error - set permanent error state
+            LOGGER.warning(() -> "Thread " + Thread.currentThread().getName() + " detected recursive initialization");
+            // Wrap in IllegalStateException to capture each caller's stack trace
+            Getter<T> errorGetter = () -> {
+                throw new IllegalStateException("Initialization failed (elsewhere) due to recursive call", e);
+            };
+            functionPointer.set(errorGetter);
+            throw new IllegalStateException("Initialization failed due to recursive call", e);
         } catch (Throwable e) {
             if (allowRetry) {
                 LOGGER.warning(() -> "Thread " + Thread.currentThread().getName() + " failed initialization, resetting for retry");

--- a/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyReference.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyReference.java
@@ -219,7 +219,7 @@ public class LazyReference<T> {
                 LOGGER.warning(() -> "Thread " + Thread.currentThread().getName() + " failed initialization, setting permanent error state");
                 // Store the original cause and create new exception on each call for accurate stack traces
                 Getter<T> errorGetter = () -> {
-                    throw new InitializationException("Initialization failed and retry is not allowed", e);
+                    throw new InitializationException("Initialization failed (elsewhere) and retry is not allowed", e);
                 };
                 functionPointer.set(errorGetter);
                 throw new InitializationException("Initialization failed and retry is not allowed", e);
@@ -231,7 +231,7 @@ public class LazyReference<T> {
     }
 
     /**
-     * Checks if initialization has completed.
+     * Checks whether initialization has completed.
      * <p>
      * Returns {@code true} if initialization succeeded or failed with {@code allowRetry=false}
      * (permanent error state). Returns {@code false} if not yet attempted or failed with

--- a/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyReference.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyReference.java
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A thread-safe lazily initialized field using atomic function pointer swapping.
+ * A thread-safe lazy reference using atomic function pointer swapping.
  * <p>
  * This implementation uses a sophisticated lock-free pattern where:
  * <ol>
@@ -39,8 +39,8 @@ import static java.util.Objects.requireNonNull;
  *
  * @param <T> the type of the lazily initialized value
  */
-public class LazyInitializedField<T> {
-    private static final Logger LOGGER = Logger.getLogger(LazyInitializedField.class.getName());
+public class LazyReference<T> {
+    private static final Logger LOGGER = Logger.getLogger(LazyReference.class.getName());
 
     /**
      * Exception thrown when lazy initialization fails and retry is not allowed.
@@ -108,21 +108,21 @@ public class LazyInitializedField<T> {
     private final Supplier<T> initializationFunctionRef = this::initializationFunction;
 
     /**
-     * Creates a new lazily initialized field with retry disabled.
+     * Creates a new lazy reference with retry disabled.
      *
      * @param initializer the supplier that will compute the value on first access
      */
-    public LazyInitializedField(Supplier<T> initializer) {
+    public LazyReference(Supplier<T> initializer) {
         this(initializer, false);
     }
 
     /**
-     * Creates a new lazily initialized field.
+     * Creates a new lazy reference.
      *
      * @param initializer the supplier that will compute the value on first access
      * @param allowRetry whether to allow retry on initialization failure
      */
-    public LazyInitializedField(Supplier<T> initializer, boolean allowRetry) {
+    public LazyReference(Supplier<T> initializer, boolean allowRetry) {
         this.initializer = requireNonNull(initializer, "initializer must not be null");
         this.allowRetry = allowRetry;
         this.functionPointer = new AtomicReference<>(initializationFunctionRef);

--- a/yoko-util/src/test/java/org/apache/yoko/util/concurrent/LazyInitializedFieldTest.java
+++ b/yoko-util/src/test/java/org/apache/yoko/util/concurrent/LazyInitializedFieldTest.java
@@ -48,12 +48,12 @@ class LazyInitializedFieldTest {
             return "initialized";
         });
 
-        assertFalse(field.isInitialized(), "Field should not be initialized initially");
+        assertFalse(field.isCompleted(), "Field should not be initialized initially");
 
         String value = field.get();
         assertEquals("initialized", value, "Should return initialized value");
         assertEquals(1, initCount.get(), "Initializer should be called exactly once");
-        assertTrue(field.isInitialized(), "Field should be initialized after first get");
+        assertTrue(field.isCompleted(), "Field should be initialized after first get");
 
         // Second call should return cached value without re-initialization
         String value2 = field.get();
@@ -184,21 +184,82 @@ class LazyInitializedFieldTest {
                 throw new RuntimeException("First attempt failed");
             }
             return "success-" + attempt;
-        });
+        }, true); // Enable retry
 
         // First attempt should fail
         assertThrows(RuntimeException.class, field::get, "First attempt should throw exception");
-        assertFalse(field.isInitialized(), "Field should not be initialized after exception");
+        assertFalse(field.isCompleted(), "Field should not be initialized after exception");
 
         // Second attempt should succeed
         String value = field.get();
         assertEquals("success-2", value, "Second attempt should succeed");
-        assertTrue(field.isInitialized(), "Field should be initialized after successful retry");
+        assertTrue(field.isCompleted(), "Field should be initialized after successful retry");
         assertEquals(2, attemptCount.get(), "Should have attempted twice");
 
         // Subsequent calls should return cached value
         assertEquals("success-2", field.get(), "Should return cached value");
         assertEquals(2, attemptCount.get(), "Should not retry after success");
+    }
+
+    @Test
+    void testInitializationWithExceptionNoRetry() {
+        AtomicInteger attemptCount = new AtomicInteger(0);
+        RuntimeException originalException = new RuntimeException("Initialization failed");
+        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+            attemptCount.incrementAndGet();
+            throw originalException;
+        }, false); // Disable retry (default behavior)
+
+        // First attempt should fail with wrapped exception
+        LazyInitializedField.InitializationException firstException = 
+            assertThrows(LazyInitializedField.InitializationException.class, field::get, 
+                "First attempt should throw InitializationException");
+        assertEquals("Initialization failed and retry is not allowed", firstException.getMessage());
+        assertSame(originalException, firstException.getCause(), "Should wrap original exception");
+        assertTrue(field.isCompleted(), "Field should be in error state after exception");
+        assertEquals(1, attemptCount.get(), "Should have attempted once");
+
+        // Second attempt should throw new wrapped exception with same cause, without retrying
+        LazyInitializedField.InitializationException secondException = 
+            assertThrows(LazyInitializedField.InitializationException.class, field::get, 
+                "Second attempt should throw wrapped exception");
+        assertEquals("Initialization failed and retry is not allowed", secondException.getMessage());
+        assertSame(originalException, secondException.getCause(), "Should wrap same original exception");
+        assertEquals(1, attemptCount.get(), "Should not retry initialization");
+
+        // Subsequent calls should continue throwing new wrapped exceptions with same cause
+        LazyInitializedField.InitializationException thirdException = 
+            assertThrows(LazyInitializedField.InitializationException.class, field::get);
+        assertEquals("Initialization failed and retry is not allowed", thirdException.getMessage());
+        assertSame(originalException, thirdException.getCause(), "Should still wrap same original exception");
+        assertEquals(1, attemptCount.get(), "Should still not retry");
+    }
+
+    @Test
+    void testInitializationWithErrorNoRetry() {
+        AtomicInteger attemptCount = new AtomicInteger(0);
+        OutOfMemoryError originalError = new OutOfMemoryError("Simulated OOM");
+        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+            attemptCount.incrementAndGet();
+            throw originalError;
+        }, false); // Disable retry
+
+        // First attempt should fail with wrapped exception (even for Error)
+        LazyInitializedField.InitializationException firstException = 
+            assertThrows(LazyInitializedField.InitializationException.class, field::get, 
+                "First attempt should throw InitializationException");
+        assertEquals("Initialization failed and retry is not allowed", firstException.getMessage());
+        assertSame(originalError, firstException.getCause(), "Should wrap original Error");
+        assertTrue(field.isCompleted(), "Field should be in error state after Error");
+        assertEquals(1, attemptCount.get(), "Should have attempted once");
+
+        // Second attempt should throw new wrapped exception with same cause, without retrying
+        LazyInitializedField.InitializationException secondException = 
+            assertThrows(LazyInitializedField.InitializationException.class, field::get, 
+                "Second attempt should throw wrapped exception");
+        assertEquals("Initialization failed and retry is not allowed", secondException.getMessage());
+        assertSame(originalError, secondException.getCause(), "Should wrap same original Error");
+        assertEquals(1, attemptCount.get(), "Should not retry initialization");
     }
 
     @Test
@@ -211,11 +272,11 @@ class LazyInitializedFieldTest {
 
         LazyInitializedField<String> field1 = new LazyInitializedField<>(supplier);
         assertEquals("initialized-1", field1.get());
-        assertTrue(field1.isInitialized());
+        assertTrue(field1.isCompleted());
 
         LazyInitializedField<String> field2 = new LazyInitializedField<>(supplier);
         assertEquals("initialized-2", field2.get());
-        assertTrue(field2.isInitialized());
+        assertTrue(field2.isCompleted());
 
         // Verify each field maintains its own value
         assertEquals("initialized-1", field1.get());
@@ -228,7 +289,7 @@ class LazyInitializedFieldTest {
         LazyInitializedField<String> field = new LazyInitializedField<>(() -> null);
 
         assertNull(field.get(), "Should support null values");
-        assertTrue(field.isInitialized(), "Field should be initialized even with null value");
+        assertTrue(field.isCompleted(), "Field should be initialized even with null value");
 
         // Second call should still return null without re-initialization
         assertNull(field.get(), "Should return null on subsequent calls");

--- a/yoko-util/src/test/java/org/apache/yoko/util/concurrent/LazyReferenceTest.java
+++ b/yoko-util/src/test/java/org/apache/yoko/util/concurrent/LazyReferenceTest.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
 import static java.util.stream.IntStream.range;
 import static org.junit.jupiter.api.Assertions.*;
 
-class LazyInitializedFieldTest {
+class LazyReferenceTest {
     private static final int INITIALIZATION_DELAY_MS = 50;
     private static final int EXPENSIVE_INITIALIZATION_DELAY_MS = 10;
     private static final int CONCURRENT_THREAD_COUNT = 10;
@@ -43,20 +43,20 @@ class LazyInitializedFieldTest {
     @Test
     void testBasicInitialization() {
         AtomicInteger initCount = new AtomicInteger(0);
-        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+        LazyReference<String> ref = new LazyReference<>(() -> {
             initCount.incrementAndGet();
             return "initialized";
         });
 
-        assertFalse(field.isCompleted(), "Field should not be initialized initially");
+        assertFalse(ref.isCompleted(), "Reference should not be initialized initially");
 
-        String value = field.get();
+        String value = ref.get();
         assertEquals("initialized", value, "Should return initialized value");
         assertEquals(1, initCount.get(), "Initializer should be called exactly once");
-        assertTrue(field.isCompleted(), "Field should be initialized after first get");
+        assertTrue(ref.isCompleted(), "Reference should be initialized after first get");
 
         // Second call should return cached value without re-initialization
-        String value2 = field.get();
+        String value2 = ref.get();
         assertEquals("initialized", value2, "Should return same value");
         assertEquals(1, initCount.get(), "Initializer should still be called only once");
     }
@@ -67,7 +67,7 @@ class LazyInitializedFieldTest {
         AtomicInteger maxConcurrentInits = new AtomicInteger(0);
         AtomicInteger currentConcurrentInits = new AtomicInteger(0);
 
-        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+        LazyReference<String> ref = new LazyReference<>(() -> {
             initCount.incrementAndGet();
             int concurrent = currentConcurrentInits.incrementAndGet();
             maxConcurrentInits.updateAndGet(max -> Math.max(max, concurrent));
@@ -96,7 +96,7 @@ class LazyInitializedFieldTest {
                     startLatch.await();
 
                     // All threads try to get the value simultaneously
-                    String value = field.get();
+                    String value = ref.get();
                     assertEquals("initialized", value, "All threads should get the same value");
                 } catch (Throwable t) {
                     error.set(t);
@@ -124,7 +124,7 @@ class LazyInitializedFieldTest {
     void testHighContentionInitialization() throws InterruptedException {
         AtomicInteger initCount = new AtomicInteger(0);
 
-        LazyInitializedField<Integer> field = new LazyInitializedField<>(() -> {
+        LazyReference<Integer> ref = new LazyReference<>(() -> {
             int count = initCount.incrementAndGet();
             // Simulate expensive initialization
             try {
@@ -145,7 +145,7 @@ class LazyInitializedFieldTest {
             executor.submit(() -> {
                 try {
                     startLatch.await();
-                    Integer value = field.get();
+                    Integer value = ref.get();
                     assertEquals(1, value.intValue(), "All threads should get value 1");
                     successCount.incrementAndGet();
                 } catch (InterruptedException e) {
@@ -168,17 +168,17 @@ class LazyInitializedFieldTest {
 
     @Test
     void testInitializationWithException() {
-        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+        LazyReference<String> ref = new LazyReference<>(() -> {
             throw new RuntimeException("Initialization failed");
         });
 
-        assertThrows(RuntimeException.class, field::get, "Should propagate initialization exception");
+        assertThrows(RuntimeException.class, ref::get, "Should propagate initialization exception");
     }
 
     @Test
     void testInitializationWithExceptionRetry() {
         AtomicInteger attemptCount = new AtomicInteger(0);
-        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+        LazyReference<String> ref = new LazyReference<>(() -> {
             int attempt = attemptCount.incrementAndGet();
             if (attempt == 1) {
                 throw new RuntimeException("First attempt failed");
@@ -187,17 +187,17 @@ class LazyInitializedFieldTest {
         }, true); // Enable retry
 
         // First attempt should fail
-        assertThrows(RuntimeException.class, field::get, "First attempt should throw exception");
-        assertFalse(field.isCompleted(), "Field should not be initialized after exception");
+        assertThrows(RuntimeException.class, ref::get, "First attempt should throw exception");
+        assertFalse(ref.isCompleted(), "Reference should not be initialized after exception");
 
         // Second attempt should succeed
-        String value = field.get();
+        String value = ref.get();
         assertEquals("success-2", value, "Second attempt should succeed");
-        assertTrue(field.isCompleted(), "Field should be initialized after successful retry");
+        assertTrue(ref.isCompleted(), "Reference should be initialized after successful retry");
         assertEquals(2, attemptCount.get(), "Should have attempted twice");
 
         // Subsequent calls should return cached value
-        assertEquals("success-2", field.get(), "Should return cached value");
+        assertEquals("success-2", ref.get(), "Should return cached value");
         assertEquals(2, attemptCount.get(), "Should not retry after success");
     }
 
@@ -205,31 +205,31 @@ class LazyInitializedFieldTest {
     void testInitializationWithExceptionNoRetry() {
         AtomicInteger attemptCount = new AtomicInteger(0);
         RuntimeException originalException = new RuntimeException("Initialization failed");
-        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+        LazyReference<String> ref = new LazyReference<>(() -> {
             attemptCount.incrementAndGet();
             throw originalException;
         }, false); // Disable retry (default behavior)
 
         // First attempt should fail with wrapped exception
-        LazyInitializedField.InitializationException firstException = 
-            assertThrows(LazyInitializedField.InitializationException.class, field::get, 
+        LazyReference.InitializationException firstException = 
+            assertThrows(LazyReference.InitializationException.class, ref::get, 
                 "First attempt should throw InitializationException");
         assertEquals("Initialization failed and retry is not allowed", firstException.getMessage());
         assertSame(originalException, firstException.getCause(), "Should wrap original exception");
-        assertTrue(field.isCompleted(), "Field should be in error state after exception");
+        assertTrue(ref.isCompleted(), "Reference should be in error state after exception");
         assertEquals(1, attemptCount.get(), "Should have attempted once");
 
         // Second attempt should throw new wrapped exception with same cause, without retrying
-        LazyInitializedField.InitializationException secondException = 
-            assertThrows(LazyInitializedField.InitializationException.class, field::get, 
+        LazyReference.InitializationException secondException = 
+            assertThrows(LazyReference.InitializationException.class, ref::get, 
                 "Second attempt should throw wrapped exception");
         assertEquals("Initialization failed and retry is not allowed", secondException.getMessage());
         assertSame(originalException, secondException.getCause(), "Should wrap same original exception");
         assertEquals(1, attemptCount.get(), "Should not retry initialization");
 
         // Subsequent calls should continue throwing new wrapped exceptions with same cause
-        LazyInitializedField.InitializationException thirdException = 
-            assertThrows(LazyInitializedField.InitializationException.class, field::get);
+        LazyReference.InitializationException thirdException = 
+            assertThrows(LazyReference.InitializationException.class, ref::get);
         assertEquals("Initialization failed and retry is not allowed", thirdException.getMessage());
         assertSame(originalException, thirdException.getCause(), "Should still wrap same original exception");
         assertEquals(1, attemptCount.get(), "Should still not retry");
@@ -239,23 +239,23 @@ class LazyInitializedFieldTest {
     void testInitializationWithErrorNoRetry() {
         AtomicInteger attemptCount = new AtomicInteger(0);
         OutOfMemoryError originalError = new OutOfMemoryError("Simulated OOM");
-        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+        LazyReference<String> ref = new LazyReference<>(() -> {
             attemptCount.incrementAndGet();
             throw originalError;
         }, false); // Disable retry
 
         // First attempt should fail with wrapped exception (even for Error)
-        LazyInitializedField.InitializationException firstException = 
-            assertThrows(LazyInitializedField.InitializationException.class, field::get, 
+        LazyReference.InitializationException firstException = 
+            assertThrows(LazyReference.InitializationException.class, ref::get, 
                 "First attempt should throw InitializationException");
         assertEquals("Initialization failed and retry is not allowed", firstException.getMessage());
         assertSame(originalError, firstException.getCause(), "Should wrap original Error");
-        assertTrue(field.isCompleted(), "Field should be in error state after Error");
+        assertTrue(ref.isCompleted(), "Reference should be in error state after Error");
         assertEquals(1, attemptCount.get(), "Should have attempted once");
 
         // Second attempt should throw new wrapped exception with same cause, without retrying
-        LazyInitializedField.InitializationException secondException = 
-            assertThrows(LazyInitializedField.InitializationException.class, field::get, 
+        LazyReference.InitializationException secondException = 
+            assertThrows(LazyReference.InitializationException.class, ref::get, 
                 "Second attempt should throw wrapped exception");
         assertEquals("Initialization failed and retry is not allowed", secondException.getMessage());
         assertSame(originalError, secondException.getCause(), "Should wrap same original Error");
@@ -270,29 +270,29 @@ class LazyInitializedFieldTest {
             return "initialized-" + count;
         };
 
-        LazyInitializedField<String> field1 = new LazyInitializedField<>(supplier);
-        assertEquals("initialized-1", field1.get());
-        assertTrue(field1.isCompleted());
+        LazyReference<String> ref1 = new LazyReference<>(supplier);
+        assertEquals("initialized-1", ref1.get());
+        assertTrue(ref1.isCompleted());
 
-        LazyInitializedField<String> field2 = new LazyInitializedField<>(supplier);
-        assertEquals("initialized-2", field2.get());
-        assertTrue(field2.isCompleted());
+        LazyReference<String> ref2 = new LazyReference<>(supplier);
+        assertEquals("initialized-2", ref2.get());
+        assertTrue(ref2.isCompleted());
 
-        // Verify each field maintains its own value
-        assertEquals("initialized-1", field1.get());
-        assertEquals("initialized-2", field2.get());
-        assertEquals(2, initCount.get(), "Initializer should be called once per field");
+        // Verify each reference maintains its own value
+        assertEquals("initialized-1", ref1.get());
+        assertEquals("initialized-2", ref2.get());
+        assertEquals(2, initCount.get(), "Initializer should be called once per reference");
     }
 
     @Test
     void testNullValue() {
-        LazyInitializedField<String> field = new LazyInitializedField<>(() -> null);
+        LazyReference<String> ref = new LazyReference<>(() -> null);
 
-        assertNull(field.get(), "Should support null values");
-        assertTrue(field.isCompleted(), "Field should be initialized even with null value");
+        assertNull(ref.get(), "Should support null values");
+        assertTrue(ref.isCompleted(), "Reference should be initialized even with null value");
 
         // Second call should still return null without re-initialization
-        assertNull(field.get(), "Should return null on subsequent calls");
+        assertNull(ref.get(), "Should return null on subsequent calls");
     }
 
     @Test
@@ -308,13 +308,13 @@ class LazyInitializedFieldTest {
         }
 
         AtomicInteger counter = new AtomicInteger(0);
-        LazyInitializedField<ComplexObject> field = new LazyInitializedField<>(() -> {
+        LazyReference<ComplexObject> ref = new LazyReference<>(() -> {
             counter.incrementAndGet();
             return new ComplexObject("test", 42);
         });
 
-        ComplexObject obj1 = field.get();
-        ComplexObject obj2 = field.get();
+        ComplexObject obj1 = ref.get();
+        ComplexObject obj2 = ref.get();
 
         assertSame(obj1, obj2, "Should return the same instance");
         assertEquals("test", obj1.name);
@@ -325,14 +325,14 @@ class LazyInitializedFieldTest {
     @Test
     void testSequentialAccess() {
         AtomicInteger initCount = new AtomicInteger(0);
-        LazyInitializedField<String> field = new LazyInitializedField<>(() -> {
+        LazyReference<String> ref = new LazyReference<>(() -> {
             initCount.incrementAndGet();
             return "value";
         });
 
         // Multiple sequential accesses
         for (int i = 0; i < SEQUENTIAL_ACCESS_COUNT; i++) {
-            assertEquals("value", field.get());
+            assertEquals("value", ref.get());
         }
 
         assertEquals(1, initCount.get(), "Should initialize only once despite many accesses");

--- a/yoko-util/src/test/java/org/apache/yoko/util/concurrent/LazyReferenceTest.java
+++ b/yoko-util/src/test/java/org/apache/yoko/util/concurrent/LazyReferenceTest.java
@@ -214,7 +214,6 @@ class LazyReferenceTest {
         LazyReference.InitializationException firstException = 
             assertThrows(LazyReference.InitializationException.class, ref::get, 
                 "First attempt should throw InitializationException");
-        assertEquals("Initialization failed and retry is not allowed", firstException.getMessage());
         assertSame(originalException, firstException.getCause(), "Should wrap original exception");
         assertTrue(ref.isCompleted(), "Reference should be in error state after exception");
         assertEquals(1, attemptCount.get(), "Should have attempted once");
@@ -223,14 +222,12 @@ class LazyReferenceTest {
         LazyReference.InitializationException secondException = 
             assertThrows(LazyReference.InitializationException.class, ref::get, 
                 "Second attempt should throw wrapped exception");
-        assertEquals("Initialization failed and retry is not allowed", secondException.getMessage());
         assertSame(originalException, secondException.getCause(), "Should wrap same original exception");
         assertEquals(1, attemptCount.get(), "Should not retry initialization");
 
         // Subsequent calls should continue throwing new wrapped exceptions with same cause
         LazyReference.InitializationException thirdException = 
             assertThrows(LazyReference.InitializationException.class, ref::get);
-        assertEquals("Initialization failed and retry is not allowed", thirdException.getMessage());
         assertSame(originalException, thirdException.getCause(), "Should still wrap same original exception");
         assertEquals(1, attemptCount.get(), "Should still not retry");
     }
@@ -248,7 +245,6 @@ class LazyReferenceTest {
         LazyReference.InitializationException firstException = 
             assertThrows(LazyReference.InitializationException.class, ref::get, 
                 "First attempt should throw InitializationException");
-        assertEquals("Initialization failed and retry is not allowed", firstException.getMessage());
         assertSame(originalError, firstException.getCause(), "Should wrap original Error");
         assertTrue(ref.isCompleted(), "Reference should be in error state after Error");
         assertEquals(1, attemptCount.get(), "Should have attempted once");
@@ -257,7 +253,6 @@ class LazyReferenceTest {
         LazyReference.InitializationException secondException = 
             assertThrows(LazyReference.InitializationException.class, ref::get, 
                 "Second attempt should throw wrapped exception");
-        assertEquals("Initialization failed and retry is not allowed", secondException.getMessage());
         assertSame(originalError, secondException.getCause(), "Should wrap same original Error");
         assertEquals(1, attemptCount.get(), "Should not retry initialization");
     }

--- a/yoko-util/src/test/java/org/apache/yoko/util/concurrent/LazyReferenceTest.java
+++ b/yoko-util/src/test/java/org/apache/yoko/util/concurrent/LazyReferenceTest.java
@@ -332,4 +332,37 @@ class LazyReferenceTest {
 
         assertEquals(1, initCount.get(), "Should initialize only once despite many accesses");
     }
+
+    @Test
+    void testRecursiveInitializationDetection() {
+        // Use array to work around Java's effectively final requirement
+        LazyReference<String>[] refHolder = new LazyReference[1];
+        
+        // Create a LazyReference that tries to call get() during initialization
+        refHolder[0] = new LazyReference<>(() -> {
+            // This should throw IllegalStateException due to recursive call
+            return refHolder[0].get();
+        });
+
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            refHolder[0]::get,
+            "Should detect recursive initialization"
+        );
+        
+        assertEquals("Initialization failed due to recursive call", exception.getMessage(),
+            "Exception message should indicate recursive initialization failure");
+        
+        assertNotNull(exception.getCause(), "Should have a cause");
+        assertTrue(exception.getCause() instanceof LazyReference.RecursiveInitializationException,
+            "Cause should be RecursiveInitializationException");
+        assertTrue(
+            exception.getCause().getMessage().contains("Recursive initialization detected"),
+            "Cause message should indicate recursive initialization"
+        );
+        assertTrue(
+            exception.getCause().getMessage().contains(Thread.currentThread().getName()),
+            "Cause message should include thread name"
+        );
+    }
 }


### PR DESCRIPTION
- **perf: optimize LazyInitializedField to avoid unnecessary Waiter allocation**
- **refector(yoko-util): add allowRetry parameter to LazyInitializedField**
