### PR TITLE
Fix issue #783: handle exceptions from client interceptors

### DIFF
--- a/testify-iiop/src/main/java/testify/iiop/annotation/ServerComms.java
+++ b/testify-iiop/src/main/java/testify/iiop/annotation/ServerComms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 IBM Corporation and others.
+ * Copyright 2026 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import javax.rmi.PortableRemoteObject;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.io.StringWriter;
+import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
@@ -362,13 +363,14 @@ final class ServerComms implements Serializable {
         return ior;
     }
 
+    @SuppressWarnings("unchecked")
     private <IMPL extends Remote, TIE extends Servant & Tie>
     void exportObject0(Member member) {
         assertServer(IS_STARTED);
         try {
             bus.log(INFO, "### exporting object from member: " + member);
-            @SuppressWarnings("unchecked cast")
             final IMPL o;
+            if (member instanceof AccessibleObject) ((AccessibleObject)member).setAccessible(true);
             if (member instanceof Field) o = (IMPL) ((Field)member).get(null);
             else if (member instanceof Method) o = (IMPL) invoke0((Method) member);
             else throw Assertions.failf("Member type not supported for object export: %s", member);

--- a/testify/src/main/java/testify/util/Private.java
+++ b/testify/src/main/java/testify/util/Private.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package testify.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utility for invoking package-private methods via reflection in tests.
+ * Provides type-safe access to methods that are not publicly accessible.
+ */
+public enum Private {
+    ;
+
+    private static final Map<Class<?>, Class<?>> PRIMITIVE_TO_WRAPPER = new HashMap<>();
+    private static final Map<Class<?>, Class<?>> WRAPPER_TO_PRIMITIVE = new HashMap<>();
+
+    static {
+        PRIMITIVE_TO_WRAPPER.put(boolean.class, Boolean.class);
+        PRIMITIVE_TO_WRAPPER.put(byte.class, Byte.class);
+        PRIMITIVE_TO_WRAPPER.put(char.class, Character.class);
+        PRIMITIVE_TO_WRAPPER.put(short.class, Short.class);
+        PRIMITIVE_TO_WRAPPER.put(int.class, Integer.class);
+        PRIMITIVE_TO_WRAPPER.put(long.class, Long.class);
+        PRIMITIVE_TO_WRAPPER.put(float.class, Float.class);
+        PRIMITIVE_TO_WRAPPER.put(double.class, Double.class);
+        PRIMITIVE_TO_WRAPPER.put(void.class, Void.class);
+
+        PRIMITIVE_TO_WRAPPER.forEach((k, v) -> WRAPPER_TO_PRIMITIVE.put(v, k));
+    }
+
+    /**
+     * Invokes a static method (including package-private) on the specified class.
+     *
+     * @param <T> the expected return type
+     * @param targetClass the class containing the method
+     * @param methodName the name of the method to invoke
+     * @param args the arguments to pass to the method (varargs)
+     * @return the result of the method invocation, cast to type T
+     * @throws RuntimeException if the method cannot be found or invoked
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T invoke(Class<?> targetClass, String methodName, Object... args) {
+        Method method = findMethod(targetClass, methodName, args);
+        try {
+            method.setAccessible(true);
+            return (T) method.invoke(null, args);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("Failed to access method: " + methodName + " on " + targetClass.getName(), e);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw new RuntimeException("Method invocation failed: " + methodName + " on " + targetClass.getName(), cause);
+        }
+    }
+
+    private static Method findMethod(Class<?> targetClass, String methodName, Object... args) {
+        Method[] methods = targetClass.getDeclaredMethods();
+        Method[] candidates = Arrays.stream(methods)
+                .filter(m -> m.getName().equals(methodName))
+                .filter(m -> parametersMatch(m.getParameterTypes(), args))
+                .toArray(Method[]::new);
+
+        if (candidates.length == 0) {
+            String availableMethods = Arrays.stream(methods)
+                    .map(m -> m.getName() + "(" + Arrays.stream(m.getParameterTypes())
+                            .map(Class::getSimpleName)
+                            .collect(Collectors.joining(", ")) + ")")
+                    .collect(Collectors.joining(", "));
+            throw new RuntimeException(
+                    "No method found: " + methodName + " with " + args.length + " parameters on " + targetClass.getName() +
+                    ". Available methods: " + availableMethods);
+        }
+
+        if (candidates.length > 1) {
+            String ambiguousMethods = Arrays.stream(candidates)
+                    .map(m -> m.getName() + "(" + Arrays.stream(m.getParameterTypes())
+                            .map(Class::getSimpleName)
+                            .collect(Collectors.joining(", ")) + ")")
+                    .collect(Collectors.joining(", "));
+            throw new RuntimeException(
+                    "Ambiguous method call: multiple methods match " + methodName + " on " + targetClass.getName() +
+                    ". Candidates: " + ambiguousMethods);
+        }
+
+        return candidates[0];
+    }
+
+    private static boolean parametersMatch(Class<?>[] paramTypes, Object[] args) {
+        if (paramTypes.length != args.length) {
+            return false;
+        }
+
+        for (int i = 0; i < paramTypes.length; i++) {
+            if (args[i] == null) {
+                // null can be assigned to any non-primitive type
+                if (paramTypes[i].isPrimitive()) {
+                    return false;
+                }
+                continue;
+            }
+
+            Class<?> argType = args[i].getClass();
+            Class<?> paramType = paramTypes[i];
+
+            // Exact match
+            if (paramType.isAssignableFrom(argType)) {
+                continue;
+            }
+
+            // Handle primitive/wrapper conversions
+            if (paramType.isPrimitive()) {
+                Class<?> wrapperType = PRIMITIVE_TO_WRAPPER.get(paramType);
+                if (wrapperType != null && wrapperType.isAssignableFrom(argType)) {
+                    continue;
+                }
+            } else {
+                Class<?> primitiveType = WRAPPER_TO_PRIMITIVE.get(paramType);
+                if (primitiveType != null) {
+                    Class<?> wrapperType = PRIMITIVE_TO_WRAPPER.get(primitiveType);
+                    if (wrapperType != null && wrapperType.isAssignableFrom(argType)) {
+                        continue;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ClientRequestInfo_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ClientRequestInfo_impl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 IBM Corporation and others.
+ * Copyright 2026 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -8,7 +8,7 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an \"AS IS\" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -41,6 +41,7 @@ import org.omg.CORBA.Policy;
 import org.omg.CORBA.SystemException;
 import org.omg.CORBA.UnknownUserException;
 import org.omg.CORBA.portable.ObjectImpl;
+import org.omg.CORBA.portable.UnknownException;
 import org.omg.IOP.IOR;
 import org.omg.IOP.ServiceContext;
 import org.omg.IOP.TaggedComponent;
@@ -65,6 +66,7 @@ import static org.apache.yoko.util.MinorCodes.describeBadInvOrder;
 import static org.apache.yoko.util.MinorCodes.describeBadParam;
 import static org.apache.yoko.util.MinorCodes.describeInvPolicy;
 import static org.omg.CORBA.CompletionStatus.COMPLETED_NO;
+import static org.omg.CORBA.CompletionStatus.COMPLETED_YES;
 
 final public class ClientRequestInfo_impl extends RequestInfo_impl implements ClientRequestInfo {
     private final List<ClientRequestInterceptor> interceptors = newSynchronizedList();
@@ -256,7 +258,6 @@ final public class ClientRequestInfo_impl extends RequestInfo_impl implements Cl
         this.argStrategy = dc.createArgumentStrategy(orb);
     }
 
-
     public void _OB_request(List<ClientRequestInterceptor> interceptors) throws LocationForward {
         // The PICurrent needs a new set of slot data
         requestSlotData = piCurrent._OB_currentSlotData();
@@ -282,6 +283,12 @@ final public class ClientRequestInfo_impl extends RequestInfo_impl implements Cl
                     replyStatus = LOCATION_FORWARD.value;
                     Delegate p = (Delegate) (((ObjectImpl) ex.forward)._get_delegate());
                     forwardReference = p._OB_IOR();
+                    _OB_reply();
+                } catch (Exception ex) {
+                    replyStatus = SYSTEM_EXCEPTION.value;
+                    UnknownException unknownException = new UnknownException(ex);
+                    unknownException.completed = COMPLETED_NO;
+                    receivedException = unknownException;
                     _OB_reply();
                 }
             }
@@ -322,12 +329,28 @@ final public class ClientRequestInfo_impl extends RequestInfo_impl implements Cl
                     }
                 } catch (SystemException ex) {
                     replyStatus = SYSTEM_EXCEPTION.value;
+                    if (null != receivedException) {
+                        ex.addSuppressed(receivedException);
+                    }
                     receivedException = ex;
                     receivedId = null;
                 } catch (ForwardRequest ex) {
                     replyStatus = LOCATION_FORWARD.value;
                     Delegate p = (Delegate) (((ObjectImpl) ex.forward)._get_delegate());
                     forwardReference = p._OB_IOR();
+                } catch (Exception ex) {
+                    if (null == receivedException) {
+                        replyStatus = SYSTEM_EXCEPTION.value;
+                        UnknownException unknownException = new UnknownException(ex);
+                        unknownException.completed = COMPLETED_YES;
+                        receivedException = unknownException;
+                        receivedId = null;
+                    } else {
+                        // an interceptor has thrown an unexpected, unchecked Java exception
+                        // rather than translating the existing exception into a known CORBA SystemException.
+                        // Since we already have an exceptional response, just add this one as suppressed
+                        receivedException.addSuppressed(ex);
+                    }
                 }
             }
         }

--- a/yoko-spec-corba/src/main/java/org/omg/CORBA/portable/UnknownException.java
+++ b/yoko-spec-corba/src/main/java/org/omg/CORBA/portable/UnknownException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 IBM Corporation and others.
+ * Copyright 2026 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -8,7 +8,7 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an \"AS IS\" BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -23,5 +23,6 @@ public class UnknownException extends org.omg.CORBA.SystemException {
     public UnknownException(Throwable ex) {
         super("originalEx: " + ex, 0, org.omg.CORBA.CompletionStatus.COMPLETED_MAYBE);
         originalEx = ex;
+        initCause(ex);
     }
 }

--- a/yoko-util/src/main/java/org/apache/yoko/util/cmsf/CmsfThreadLocal.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/cmsf/CmsfThreadLocal.java
@@ -114,4 +114,18 @@ public final class CmsfThreadLocal {
         LOGGER.finer(() -> "CMSF thread local stack reset");
         cmsfInfo.remove();
     }
+
+    /**
+     * Returns the current stack depth for testing purposes only.
+     */
+    static int getStackDepth() {
+        final CmsfInfo info = cmsfInfo.get();
+        int depth = 0;
+        Frame current = info.head;
+        while (Frame.DEFAULT != current) {
+            depth++;
+            current = current.prev;
+        }
+        return depth;
+    }
 }

--- a/yoko-util/src/main/java/org/apache/yoko/util/rofl/RoflThreadLocal.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/rofl/RoflThreadLocal.java
@@ -84,4 +84,21 @@ public final class RoflThreadLocal {
         LOGGER.finer(() -> "ROFL thread local stack reset");
         threadLocalStack.remove();
     }
+
+    /**
+     * Returns the current stack depth for testing purposes only.
+     * This method is package-private and should not be used in production code.
+     *
+     * @return the number of frames currently on the stack (0 means empty/clean state)
+     */
+    static int getStackDepth() {
+        final Stack info = threadLocalStack.get();
+        int depth = 0;
+        Frame current = info.head;
+        while (current != Frame.DEFAULT) {
+            depth++;
+            current = current.prev;
+        }
+        return depth;
+    }
 }

--- a/yoko-util/src/main/java/org/apache/yoko/util/yasf/YasfThreadLocal.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/yasf/YasfThreadLocal.java
@@ -98,4 +98,21 @@ public final class YasfThreadLocal {
         LOGGER.finer(() -> "YASF thread local stack reset");
         yasfInfo.remove();
     }
+
+    /**
+     * Returns the current stack depth for testing purposes only.
+     * This method is package-private and should not be used in production code.
+     *
+     * @return the number of frames currently on the stack (0 means empty/clean state)
+     */
+    static int getStackDepth() {
+        final YasfInfo info = yasfInfo.get();
+        int depth = 0;
+        Frame current = info.head;
+        while (current != Frame.DEFAULT) {
+            depth++;
+            current = current.prev;
+        }
+        return depth;
+    }
 }

--- a/yoko-verify/src/test/java-testify/org/apache/yoko/ThreadLocalPollutionTest.java
+++ b/yoko-verify/src/test/java-testify/org/apache/yoko/ThreadLocalPollutionTest.java
@@ -198,8 +198,9 @@ class ThreadLocalPollutionTestWithUncheckedException extends ThreadLocalPollutio
 
     ThreadLocalPollutionTestWithUncheckedException() {
         super(buildExpectations()
-                .ifConfiguredToThrowOn(NEVER, SEND_POLL, RECEIVE_REPLY, RECEIVE_OTHER).expect(UncheckedException.class)
-                .ifConfiguredToThrowOn(SEND_REQUEST, RECEIVE_EXCEPTION).expect(InterceptorException.class));
+                // Note: RECEIVE_EXCEPTION does throw, but the InterceptorException is suppressed
+                .ifConfiguredToThrowOn(NEVER, SEND_POLL, RECEIVE_REPLY, RECEIVE_EXCEPTION, RECEIVE_OTHER).expect(UncheckedException.class)
+                .ifConfiguredToThrowOn(SEND_REQUEST).expect(InterceptorException.class));
     }
 }
 

--- a/yoko-verify/src/test/java-testify/org/apache/yoko/ThreadLocalPollutionTest.java
+++ b/yoko-verify/src/test/java-testify/org/apache/yoko/ThreadLocalPollutionTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.yoko;
+
+import acme.Echo;
+import org.apache.yoko.ThreadLocalPollutionTest.ExceptionThrowingInterceptor.InterceptorException;
+import org.apache.yoko.ThreadLocalPollutionTest.ExceptionThrowingInterceptor.WhenToThrow;
+import org.apache.yoko.util.cmsf.CmsfThreadLocal;
+import org.apache.yoko.util.rofl.RoflThreadLocal;
+import org.apache.yoko.util.yasf.YasfThreadLocal;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.omg.CORBA.ORB;
+import org.omg.PortableInterceptor.ClientRequestInfo;
+import testify.iiop.TestClientRequestInterceptor;
+import testify.iiop.annotation.ConfigureOrb;
+import testify.iiop.annotation.ConfigureOrb.UseWithOrb;
+import testify.iiop.annotation.ConfigureServer;
+import testify.iiop.annotation.ConfigureServer.BeforeServer;
+import testify.iiop.annotation.ConfigureServer.RemoteImpl;
+
+import java.rmi.RemoteException;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.util.Collections.unmodifiableMap;
+import static org.apache.yoko.ThreadLocalPollutionTest.ExceptionThrowingInterceptor.WhenToThrow.NEVER;
+import static org.apache.yoko.ThreadLocalPollutionTest.ExceptionThrowingInterceptor.WhenToThrow.RECEIVE_EXCEPTION;
+import static org.apache.yoko.ThreadLocalPollutionTest.ExceptionThrowingInterceptor.WhenToThrow.RECEIVE_OTHER;
+import static org.apache.yoko.ThreadLocalPollutionTest.ExceptionThrowingInterceptor.WhenToThrow.RECEIVE_REPLY;
+import static org.apache.yoko.ThreadLocalPollutionTest.ExceptionThrowingInterceptor.WhenToThrow.SEND_POLL;
+import static org.apache.yoko.ThreadLocalPollutionTest.ExceptionThrowingInterceptor.WhenToThrow.SEND_REQUEST;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static testify.iiop.annotation.ConfigureOrb.UseWithOrb.InitializerScope.CLIENT;
+import static testify.util.Private.invoke;
+
+/**
+ * Tests that demonstrate ThreadLocal pollution when a client interceptor
+ * throws an exception from receive_reply(), preventing cleanup of CMSF, YASF, and ROFL ThreadLocals.
+ *
+ * @see <a href="https://github.com/OpenLiberty/yoko/issues/783">Issue #783</a>
+ */
+@ConfigureServer
+public abstract class ThreadLocalPollutionTest {
+    static String echo(String s) { return "Echo: " + s; }
+    static String sleepyEcho(String s) {
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException ignored) {
+        }
+        return s;
+    }
+
+    /**
+     * Minimal interceptor that throws an exception from receive_reply() to interrupt
+     * the interceptor chain and prevent ThreadLocal cleanup.
+     */
+    @UseWithOrb(scope = CLIENT)
+    public static class ExceptionThrowingInterceptor implements TestClientRequestInterceptor {
+        enum WhenToThrow { NEVER, SEND_POLL, SEND_REQUEST, RECEIVE_REPLY, RECEIVE_EXCEPTION, RECEIVE_OTHER }
+
+        static class InterceptorException extends RuntimeException {}
+
+        private static volatile WhenToThrow throwOn = NEVER;
+
+        @Override public String name() { return "ExceptionThrowingInterceptor"; }
+        @Override public void send_poll(ClientRequestInfo ri) {
+            System.err.println("ExceptionThrowingInterceptor.send_poll: throwOn=" + throwOn);
+            if (throwOn == SEND_POLL) throw new InterceptorException();
+        }
+        @Override public void send_request(ClientRequestInfo ri) {
+            System.err.println("ExceptionThrowingInterceptor.send_request: throwOn=" + throwOn);
+            if (throwOn == SEND_REQUEST) throw new InterceptorException();
+        }
+        @Override public void receive_reply(ClientRequestInfo ri) {
+            System.err.println("ExceptionThrowingInterceptor.receive_reply: throwOn=" + throwOn);
+            if (throwOn == RECEIVE_REPLY) throw new InterceptorException();
+        }
+        @Override  public void receive_exception(ClientRequestInfo ri) {
+            System.err.println("ExceptionThrowingInterceptor.receive_exception: throwOn=" + throwOn);
+            if (throwOn == RECEIVE_EXCEPTION) throw new InterceptorException();
+        }
+        @Override public void receive_other(ClientRequestInfo ri) {
+            System.err.println("ExceptionThrowingInterceptor.receive_other: throwOn=" + throwOn);
+            if (throwOn == RECEIVE_OTHER) throw new InterceptorException();
+        }
+    }
+
+    /** These are the interception points which can be configured to throw exceptions that would result in Exceptions */
+    private final Map<WhenToThrow, Class<? extends Throwable>> expectedExceptions;
+
+    ThreadLocalPollutionTest(ExceptionExpecter builder) { this.expectedExceptions = builder.getExpectations(); }
+
+    @BeforeEach
+    void ensureCleanState() { cleanUp(); }
+
+    @AfterEach
+    void checkForThreadPollution() {
+        int cmsfDepth = invoke(CmsfThreadLocal.class, "getStackDepth");
+        assertEquals(0, cmsfDepth, "CMSF stack should be empty");
+
+        int roflDepth = invoke(RoflThreadLocal.class, "getStackDepth");
+        assertEquals(0, roflDepth, "ROFL stack should be empty");
+
+        int yasfDepth = invoke(YasfThreadLocal.class, "getStackDepth");
+        assertEquals(0, yasfDepth, "Stack should be empty");
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        CmsfThreadLocal.reset();
+        YasfThreadLocal.reset();
+        RoflThreadLocal.reset();
+    }
+
+    @ParameterizedTest
+    @EnumSource(WhenToThrow.class)
+    void testThreadLocalPollution(WhenToThrow whenToThrow, Echo service, TestInfo testInfo) throws Exception {
+        //Assumptions.assumeTrue(whenToThrow == SEND_REQUEST);
+        invokeService(whenToThrow, service, testInfo.getDisplayName());
+    }
+
+    @ParameterizedTest
+    @EnumSource(WhenToThrow.class)
+    void testStackDepthDoesNotGrowWithMultipleCalls(WhenToThrow whenToThrow, Echo service, TestInfo testInfo) throws Exception {
+        for (int i = 0; i < 5; i++) invokeService(whenToThrow, service, testInfo.getDisplayName() + i);
+    }
+
+    void invokeService(WhenToThrow whenToThrow, Echo service, String payload) throws RemoteException {
+        ExceptionThrowingInterceptor.throwOn = whenToThrow;
+        if (expectedExceptions.containsKey(whenToThrow)) {
+            assertThrows(expectedExceptions.get(whenToThrow), () -> service.echo(payload));
+        } else {
+            assertEquals(echo(payload), service.echo(payload));
+        }
+    }
+
+    interface ExceptionExpecter {
+        ExceptionSpecifier ifConfiguredToThrowOn(WhenToThrow... interceptionPoints);
+        Map<WhenToThrow, Class<? extends Throwable>> getExpectations();
+    }
+
+    interface ExceptionSpecifier {
+        ExceptionExpecter expect(Class<? extends Throwable> exceptionClass);
+    }
+
+    static ExceptionExpecter buildExpectations() {
+        var expectations =  new EnumMap<WhenToThrow, Class<? extends Throwable>>(WhenToThrow.class);
+        return new ExceptionExpecter() {
+            public ExceptionSpecifier ifConfiguredToThrowOn(WhenToThrow... interceptionPoints) {
+                return c -> { Stream.of(interceptionPoints).forEach(p -> expectations.put(p, c)); return this; };
+            }
+
+            public Map<WhenToThrow, Class<? extends Throwable>> getExpectations() {
+                return unmodifiableMap(expectations.clone());
+            }
+        };
+    }
+}
+
+@ConfigureServer
+class ThreadLocalPollutionTestWithSimpleEcho extends ThreadLocalPollutionTest {
+    @RemoteImpl
+    public static final Echo REMOTE = ThreadLocalPollutionTest::echo;
+
+    ThreadLocalPollutionTestWithSimpleEcho() {
+        super(buildExpectations().ifConfiguredToThrowOn(SEND_REQUEST, RECEIVE_REPLY).expect(InterceptorException.class));
+    }
+}
+
+@ConfigureServer
+class ThreadLocalPollutionTestWithUncheckedException extends ThreadLocalPollutionTest {
+    static class UncheckedException extends RuntimeException {}
+
+    @RemoteImpl
+    public static final Echo REMOTE = s -> { throw new UncheckedException(); };
+
+    ThreadLocalPollutionTestWithUncheckedException() {
+        super(buildExpectations()
+                .ifConfiguredToThrowOn(NEVER, SEND_POLL, RECEIVE_REPLY, RECEIVE_OTHER).expect(UncheckedException.class)
+                .ifConfiguredToThrowOn(SEND_REQUEST, RECEIVE_EXCEPTION).expect(InterceptorException.class));
+    }
+}
+
+@ConfigureServer(clientOrb = @ConfigureOrb(props = "yoko.orb.policy.request_timeout=1"))
+class ThreadLocalPollutionTestWithRequestTimeout extends ThreadLocalPollutionTest {
+    @RemoteImpl
+    public static final Echo REMOTE = ThreadLocalPollutionTest::sleepyEcho;
+
+    ThreadLocalPollutionTestWithRequestTimeout() {
+        super(buildExpectations()
+                // Note: RECEIVE_EXCEPTION *does* result in an InterceptorException being thrown on timeout,
+                // but the ORB swallows this and propagates the NO_RESPONSE from the timeout anyway.
+                .ifConfiguredToThrowOn(NEVER, SEND_POLL, RECEIVE_REPLY, RECEIVE_EXCEPTION, RECEIVE_OTHER).expect(RemoteException.class)
+                .ifConfiguredToThrowOn(SEND_REQUEST).expect(InterceptorException.class));
+    }
+}
+
+@ConfigureServer
+class ThreadLocalPollutionTestWithShutdown extends ThreadLocalPollutionTest {
+    public static ORB serverOrb;
+    @RemoteImpl
+    public static final Echo REMOTE = s -> {
+        serverOrb.shutdown(false);
+        return echo(s);
+    };
+
+    @BeforeServer
+    public static void stashServerOrb(ORB orb) { serverOrb = orb; }
+
+    ThreadLocalPollutionTestWithShutdown() {
+        super(buildExpectations().ifConfiguredToThrowOn(SEND_REQUEST, RECEIVE_REPLY).expect(InterceptorException.class));
+    }
+}


### PR DESCRIPTION
- **test(framework): support non-public test classes**
- **test: add comprehensive tests for ThreadLocal pollution bug #783**
- **fix(interceptor): handle unexpected exceptions in client request interceptors**
