### PR TITLE
fix: skip adding undefined serialPersistentFields to deserialization map

### DIFF
--- a/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/ValueMemberFieldDescriptor.java
+++ b/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/ValueMemberFieldDescriptor.java
@@ -181,8 +181,9 @@ class ValueMemberFieldDescriptor extends FieldDescriptor {
 
     @Override
     void readFieldIntoMap(ObjectReader reader, Map map) throws IOException {
-        Object value = readValueByTypeCode(reader);
-        map.put(java_name, value);
+        // Read the value from the stream based on TypeCode, but don't add it to the Map
+        // as it wasn't defined in serialPersistentFields
+        readValueByTypeCode(reader);
     }
 
     @Override


### PR DESCRIPTION
Previously, ValueMemberFieldDescriptor would read values and add them to the
map even when they weren't defined in serialPersistentFields. This change
ensures we still consume the value from the stream (to maintain stream
position) but don't populate the map with undefined fields.
