### PR TITLE
test: add client interceptor Flow Stack exception handling test

### DIFF
--- a/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ArgumentStrategyNull.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ArgumentStrategyNull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 IBM Corporation and others.
+ * Copyright 2026, 2021 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,12 +37,12 @@ final class ArgumentStrategyNull extends ArgumentStrategy {
                     MinorCodes.MinorInvalidPICall,
                     org.omg.CORBA.CompletionStatus.COMPLETED_NO);
 
-        throw new org.omg.CORBA.NO_RESOURCES(
-                MinorCodes
-                        .describeNoResources(MinorCodes.MinorInvalidBinding)
-                        + ": arguments unavailable",
-                MinorCodes.MinorInvalidBinding,
-                org.omg.CORBA.CompletionStatus.COMPLETED_NO);
+        // When arguments are marked as available but we don't have type information,
+        // return an empty array. This allows portable interceptors to function even
+        // when using invocation styles that don't provide detailed type metadata.
+        // This is compliant with CORBA spec which states arguments() should not throw
+        // when called at appropriate interception points.
+        return new org.omg.Dynamic.Parameter[0];
     }
 
     //

--- a/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ArgumentStrategyNull.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ArgumentStrategyNull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026, 2021 IBM Corporation and others.
+ * Copyright 2021 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,12 +37,12 @@ final class ArgumentStrategyNull extends ArgumentStrategy {
                     MinorCodes.MinorInvalidPICall,
                     org.omg.CORBA.CompletionStatus.COMPLETED_NO);
 
-        // When arguments are marked as available but we don't have type information,
-        // return an empty array. This allows portable interceptors to function even
-        // when using invocation styles that don't provide detailed type metadata.
-        // This is compliant with CORBA spec which states arguments() should not throw
-        // when called at appropriate interception points.
-        return new org.omg.Dynamic.Parameter[0];
+        throw new org.omg.CORBA.NO_RESOURCES(
+                MinorCodes
+                        .describeNoResources(MinorCodes.MinorInvalidBinding)
+                        + ": arguments unavailable",
+                MinorCodes.MinorInvalidBinding,
+                org.omg.CORBA.CompletionStatus.COMPLETED_NO);
     }
 
     //

--- a/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ClientRequestInfo_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ClientRequestInfo_impl.java
@@ -349,6 +349,14 @@ final public class ClientRequestInfo_impl extends RequestInfo_impl implements Cl
                                 ex.completed = originalEx.completed;
                             }
                         }
+                    } else {
+                        // CORBA spec v3.0.3 - 21.3.6.3: Compliant Interceptors shall properly follow completion_status semantics
+                        // if they raise a system exception from receive_reply(). The completion_status shall be COMPLETED_YES
+                        if (COMPLETED_YES != ex.completed) {
+                            REQ_OUT_LOG.warning(() -> "Correcting completion status on new exception from receive_reply interceptor "
+                                    + i.getClass() + ": was " + ex.completed + " and is: " + COMPLETED_YES);
+                            ex.completed = COMPLETED_YES;
+                        }
                     }
                     receivedException = ex;
                     receivedId = null;

--- a/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ClientRequestInfo_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ClientRequestInfo_impl.java
@@ -278,7 +278,9 @@ final public class ClientRequestInfo_impl extends RequestInfo_impl implements Cl
                     this.interceptors.add(interceptor);
                 } catch (SystemException ex) {
                     replyStatus = SYSTEM_EXCEPTION.value;
-                    // correct completion status
+                    // CORBA spec v3.0.3 - 21.3.6.1: Compliant Interceptors shall properly follow completion_status
+                    // semantics if they raise a system exception from this interception point. The completion_status
+                    // shall be COMPLETED_NO
                     if (COMPLETED_NO != ex.completed) {
                         REQ_OUT_LOG.warning(() -> "Correcting completion status on new exception from interceptor " + interceptor.getClass() + ": was " + ex.completed + " and is: " + COMPLETED_NO);
                         ex.completed = COMPLETED_NO;
@@ -337,6 +339,16 @@ final public class ClientRequestInfo_impl extends RequestInfo_impl implements Cl
                     replyStatus = SYSTEM_EXCEPTION.value;
                     if (null != receivedException) {
                         ex.addSuppressed(receivedException);
+                        // CORBA spec v3.0.3 - 21.3.6.4: if the original exception is a system exception,
+                        // the completion_status of the new exception shall be the same as on the original
+                        if (receivedException instanceof SystemException) {
+                            SystemException originalEx = (SystemException) receivedException;
+                            if (ex.completed != originalEx.completed) {
+                                REQ_OUT_LOG.warning(() -> "Correcting completion status on new exception from receive_exception interceptor: was "
+                                    + ex.completed + " and should be " + originalEx.completed + " (from original exception)");
+                                ex.completed = originalEx.completed;
+                            }
+                        }
                     }
                     receivedException = ex;
                     receivedId = null;

--- a/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ClientRequestInfo_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ClientRequestInfo_impl.java
@@ -58,6 +58,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static java.util.Arrays.copyOf;
+import static org.apache.yoko.logging.VerboseLogging.REQ_OUT_LOG;
 import static org.apache.yoko.util.CollectionExtras.newSynchronizedList;
 import static org.apache.yoko.util.MinorCodes.MinorInvalidComponentId;
 import static org.apache.yoko.util.MinorCodes.MinorInvalidPICall;
@@ -277,6 +278,11 @@ final public class ClientRequestInfo_impl extends RequestInfo_impl implements Cl
                     this.interceptors.add(interceptor);
                 } catch (SystemException ex) {
                     replyStatus = SYSTEM_EXCEPTION.value;
+                    // correct completion status
+                    if (COMPLETED_NO != ex.completed) {
+                        REQ_OUT_LOG.warning(() -> "Correcting completion status on new exception from interceptor " + interceptor.getClass() + ": was " + ex.completed + " and is: " + COMPLETED_NO);
+                        ex.completed = COMPLETED_NO;
+                    }
                     receivedException = ex;
                     _OB_reply();
                 } catch (ForwardRequest ex) {

--- a/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ServerRequestInfo_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ServerRequestInfo_impl.java
@@ -58,7 +58,7 @@ import org.omg.PortableServer.Servant;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.apache.yoko.logging.VerboseLogging.REQ_OUT_LOG;
+import static org.apache.yoko.logging.VerboseLogging.REQ_IN_LOG;
 import static org.apache.yoko.util.CollectionExtras.newSynchronizedList;
 import static org.apache.yoko.util.CollectionExtras.removeInReverse;
 import static org.apache.yoko.util.MinorCodes.MinorInvalidPICall;
@@ -351,7 +351,7 @@ final public class ServerRequestInfo_impl extends RequestInfo_impl implements Se
                     // correct completion status
                     CompletionStatus expected = oldE instanceof SystemException ? ((SystemException)oldE).completed : COMPLETED_YES;
                     if (expected != newE.completed) {
-                        REQ_OUT_LOG.warning(() -> "Correcting completion status on new exception from interceptor " + i.getClass() + ": was " + newE.completed + " and is: " + expected);
+                        REQ_IN_LOG.warning(() -> "Correcting completion status on new exception from interceptor " + i.getClass() + ": was " + newE.completed + " and is: " + expected);
                         newE.completed = expected;
                     }
                     throw newE;
@@ -384,7 +384,7 @@ final public class ServerRequestInfo_impl extends RequestInfo_impl implements Se
                 } catch (SystemException newE) {
                     // correct completion status
                     if (COMPLETED_NO != newE.completed) {
-                        REQ_OUT_LOG.warning(() -> "Correcting completion status on new exception from interceptor " + i.getClass() + ": was " + newE.completed + " and is: " + COMPLETED_NO);
+                        REQ_IN_LOG.warning(() -> "Correcting completion status on new exception from interceptor " + i.getClass() + ": was " + newE.completed + " and is: " + COMPLETED_NO);
                         newE.completed = COMPLETED_NO;
                     }
                     throw newE;

--- a/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
+++ b/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
@@ -17,217 +17,59 @@
  */
 package org.omg.PortableInterceptor;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
+import acme.Echo;
 import org.junit.jupiter.api.Test;
-import org.omg.CORBA.CompletionStatus;
-import org.omg.CORBA.LocalObject;
+import org.mockito.Mockito;
 import org.omg.CORBA.NO_PERMISSION;
-import org.omg.CORBA.ORB;
-import org.omg.CORBA.Policy;
-import org.omg.IOP.CodecFactory;
-import org.omg.IOP.CodecFactoryHelper;
-import org.omg.PortableInterceptor.ORBInitInfoPackage.DuplicateName;
-import org.omg.PortableServer.POA;
-import org.omg.PortableServer.POAManager;
-import org.omg.PortableServer.ServantLocator;
-import testify.bus.Bus;
-import testify.bus.key.StringKey;
 import testify.iiop.TestORBInitializer;
-import testify.iiop.annotation.ConfigureOrb;
 import testify.iiop.annotation.ConfigureOrb.UseWithOrb;
 import testify.iiop.annotation.ConfigureServer;
-import testify.iiop.annotation.ConfigureServer.BeforeServer;
+import testify.iiop.annotation.ConfigureServer.RemoteImpl;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.rmi.RemoteException;
 
-import static java.util.Objects.requireNonNull;
-import static org.apache.yoko.orb.PortableServer.PolicyValue.NON_RETAIN;
-import static org.apache.yoko.orb.PortableServer.PolicyValue.NO_IMPLICIT_ACTIVATION;
-import static org.apache.yoko.orb.PortableServer.PolicyValue.PERSISTENT;
-import static org.apache.yoko.orb.PortableServer.PolicyValue.USER_ID;
-import static org.apache.yoko.orb.PortableServer.PolicyValue.USE_SERVANT_MANAGER;
-import static org.apache.yoko.orb.PortableServer.PolicyValue.create_POA;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.omg.CORBA.CompletionStatus.COMPLETED_MAYBE;
 import static org.omg.CORBA.CompletionStatus.COMPLETED_NO;
-import static org.omg.CORBA.SetOverrideType.ADD_OVERRIDE;
 import static testify.iiop.annotation.ConfigureOrb.UseWithOrb.InitializerScope.CLIENT;
-import static testify.iiop.annotation.ConfigureOrb.UseWithOrb.InitializerScope.SERVER;
 
 /**
  * Test client-side interceptor exception handling with Flow Stack verification.
- * Implements TC-CLIENT-001 from the interceptor exception test plan.
  */
-@ConfigureServer(
-        clientOrb = @ConfigureOrb(props = "yoko.orb.id=client orb"),
-        serverOrb = @ConfigureOrb(props = "yoko.orb.id=server orb")
-)
+@ConfigureServer
 public class ClientExceptionFlowTest {
-    private static ClientProxyManager clientProxyManager;
-    private static Bus clientBus;
-    private static ORB clientOrb;
-    private static Policy[] policies;
-    static int serverSlotId;
+    private static final ClientRequestInterceptor CI1 = Mockito.mock(ClientRequestInterceptor.class, "CI1");
+    private static final ClientRequestInterceptor CI2 = Mockito.mock(ClientRequestInterceptor.class, "CI2");
+    private static final ClientRequestInterceptor CI3 = Mockito.mock(ClientRequestInterceptor.class, "CI3");
+    private static final ServerRequestInterceptor SI = Mockito.mock(ServerRequestInterceptor.class, "SI");
 
-    enum IorKey implements StringKey {IMPL} //could possibly extract IorKey from PortableInterceptorTest and use a common enum
-
-    /**
-     * Tracks interceptor execution flow for verification.
-     */
-    static class ExecutionTracker {
-        private final List<String> events = Collections.synchronizedList(new ArrayList<>());
-
-        void record(String event) {
-            events.add(event);
-        }
-
-        List<String> getEvents() {
-            return new ArrayList<>(events);
-        }
-
-        void clear() {
-            events.clear();
-        }
+    static {
+        Mockito.when(CI1.name()).thenReturn("CI1");
+        Mockito.when(CI2.name()).thenReturn("CI2");
+        Mockito.when(CI3.name()).thenReturn("CI3");
+        Mockito.when(SI.name()).thenReturn("SI");
     }
 
-    /**
-     * Test interceptor that records execution and can throw exceptions.
-     */
-    static class TrackingInterceptor extends LocalObject implements ClientRequestInterceptor {
-        private final String name;
-        private final ExecutionTracker tracker;
-        private boolean throwInSendRequest = false;
-        private NO_PERMISSION exceptionToThrow = null;
+    @RemoteImpl
+    public static final Echo impl = ClientExceptionFlowTest::convertString;
 
-        TrackingInterceptor(String name, ExecutionTracker tracker) {
-            this.name = name;
-            this.tracker = tracker;
-        }
-
-        void setThrowInSendRequest(NO_PERMISSION exception) {
-            this.throwInSendRequest = true;
-            this.exceptionToThrow = exception;
-        }
-
-        void clearThrow() {
-            this.throwInSendRequest = false;
-            this.exceptionToThrow = null;
-        }
-
-        @Override
-        public String name() {
-            return name;
-        }
-
-        @Override
-        public void destroy() {
-            tracker.record(name + ".destroy()");
-        }
-
-        @Override
-        public void send_request(ClientRequestInfo ri) throws ForwardRequest {
-            tracker.record(name + ".send_request()");
-            if (throwInSendRequest && exceptionToThrow != null) {
-                tracker.record(name + ".send_request() throwing " + exceptionToThrow.getClass().getSimpleName());
-                throw exceptionToThrow;
-            }
-        }
-
-        @Override
-        public void send_poll(ClientRequestInfo ri) {
-            tracker.record(name + ".send_poll()");
-        }
-
-        @Override
-        public void receive_reply(ClientRequestInfo ri) {
-            tracker.record(name + ".receive_reply()");
-        }
-
-        @Override
-        public void receive_other(ClientRequestInfo ri) throws ForwardRequest {
-            tracker.record(name + ".receive_other()");
-        }
-
-        @Override
-        public void receive_exception(ClientRequestInfo ri) throws ForwardRequest {
-            tracker.record(name + ".receive_exception()");
-        }
-    }
+    private static String convertString(String s) { return '#' + s + '#'; }
 
     @UseWithOrb(scope = CLIENT)
     public static class ClientOrbInitializer implements TestORBInitializer {
         @Override
         public void pre_init(ORBInitInfo info) {
-            clientProxyManager = new ClientProxyManager(info);
+            assertDoesNotThrow(() -> info.add_client_request_interceptor(CI1));
+            assertDoesNotThrow(() -> info.add_client_request_interceptor(CI2));
+            assertDoesNotThrow(() -> info.add_client_request_interceptor(CI3));
         }
-    }
-
-    @UseWithOrb(scope = SERVER)
-    public static class ServerOrbInitializer implements TestORBInitializer {
-        @Override
-        public void pre_init(ORBInitInfo info) {
-            try {
-                serverSlotId = info.allocate_slot_id();
-                CodecFactory codecFactory = info.codec_factory();
-                info.add_server_request_interceptor(
-                    new ServerTestInterceptor_impl(serverSlotId, codecFactory)
-                );
-            } catch (DuplicateName e) {
-                throw new RuntimeException(e);
-            }
-        }
-    }
-
-    @BeforeServer
-    public static void beforeServer(Bus serverBus, ORB serverOrb, POA rootPoa) throws Exception {
-        assertNotNull(CodecFactoryHelper.narrow(serverOrb.resolve_initial_references("CodecFactory")));
-        POAManager poaMgr = rootPoa.the_POAManager();
-
-        POA persistentPOA = create_POA("persistent", rootPoa, poaMgr,
-                PERSISTENT, USER_ID, USE_SERVANT_MANAGER, NON_RETAIN, NO_IMPLICIT_ACTIVATION);
-
-        // Create servant objects
-        TestInterface_impl impl = new TestInterface_impl(serverOrb, persistentPOA, serverSlotId);
-        TestInterfaceDSI_impl dsiImpl = new TestInterfaceDSI_impl(serverOrb, serverSlotId);
-
-        // Install the servant locator in the POA
-        TestLocator_impl locatorImpl = new TestLocator_impl(serverOrb, impl, dsiImpl);
-        ServantLocator locator = locatorImpl._this(serverOrb);
-        persistentPOA.set_servant_manager(locator);
-
-        // Create and publish the persistent object reference
-        org.omg.CORBA.Object objImpl = persistentPOA.create_reference_with_id(
-            "test".getBytes(),
-            "IDL:TestInterface:1.0"
-        );
-        serverBus.put(IorKey.IMPL, serverOrb.object_to_string(objImpl));
-    }
-
-    @BeforeAll
-    public static void beforeClient(Bus clientBus, ORB clientOrb) {
-        ClientExceptionFlowTest.clientBus = clientBus;
-        ClientExceptionFlowTest.clientOrb = clientOrb;
-        policies = new Policy[0];
-    }
-
-    private TestInterface getTestInterface() {
-        String impl = clientBus.get(IorKey.IMPL);
-        org.omg.CORBA.Object obj = clientOrb.string_to_object(impl)._set_policy_override(policies, ADD_OVERRIDE);
-        return requireNonNull(TestInterfaceHelper.narrow(obj));
-    }
-
-    @AfterEach
-    public void clearClientInterceptors() {
-        clientProxyManager.clearInterceptors();
     }
 
     /**
-     * TC-CLIENT-001: Exception in send_request()
+     * Exception in send_request()
      * Verifies that when CI2 throws an exception in send_request():
      * - CI1.send_request() executes successfully
      * - CI2.send_request() throws NO_PERMISSION with COMPLETED_NO
@@ -239,71 +81,26 @@ public class ClientExceptionFlowTest {
      * - No network request is sent
      */
     @Test
-    void testExceptionInSendRequest() {
-        ExecutionTracker tracker = new ExecutionTracker();
-
-        // Create three interceptors
-        TrackingInterceptor ci1 = new TrackingInterceptor("CI1", tracker);
-        TrackingInterceptor ci2 = new TrackingInterceptor("CI2", tracker);
-        TrackingInterceptor ci3 = new TrackingInterceptor("CI3", tracker);
-
-        // Configure CI2 to throw NO_PERMISSION in send_request()
-        NO_PERMISSION expectedException = new NO_PERMISSION("Test exception", 0, COMPLETED_NO);
-        ci2.setThrowInSendRequest(expectedException);
-
-        // Register interceptors
-        clientProxyManager.setInterceptor(0, ci1);
-        clientProxyManager.setInterceptor(1, ci2);
-        clientProxyManager.setInterceptor(2, ci3);
-
-        TestInterface ti = getTestInterface();
+    void testExceptionInSendRequest(Echo stub) throws Exception {
+        // Configure CI2 to throw NO_PERMISSION in send_request() using lambda
+        Mockito.doAnswer(invocation -> {
+            // A well-behaved interceptor would only throw with COMPLETED_NO,
+            // but Yoko should also *ensure* the status is COMPLETED_NO.
+            throw new NO_PERMISSION("Test exception", 0, COMPLETED_MAYBE);
+        }).when(CI2).send_request(Mockito.any(ClientRequestInfo.class));
 
         // Execute the call and verify exception is thrown
-        NO_PERMISSION thrownException = assertThrows(NO_PERMISSION.class, ti::noargs);
+        RemoteException remoteEx = assertThrows(RemoteException.class, () -> stub.echo("should throw"));
+        NO_PERMISSION corbaEx = assertInstanceOf(NO_PERMISSION.class, remoteEx.getCause());
 
         // Verify completion status
-        assertEquals(COMPLETED_NO, thrownException.completed,
-            "Exception should have COMPLETED_NO status");
+        assertEquals(COMPLETED_NO, corbaEx.completed, "Exception should have COMPLETED_NO status");
 
-        // Verify execution flow
-        List<String> events = tracker.getEvents();
-
-        // Expected flow:
-        // 1. CI1.send_request() - executes successfully
-        // 2. CI2.send_request() - throws exception
-        // 3. CI3.send_request() - NOT called (never pushed to Flow Stack)
-        // 4. CI1.receive_exception() - called (on Flow Stack)
-        // 5. CI2.receive_exception() - NOT called (threw the exception)
-        // 6. CI3.receive_exception() - NOT called (never on Flow Stack)
-
-        assertTrue(events.contains("CI1.send_request()"), "CI1.send_request() should be called");
-        assertTrue(events.contains("CI2.send_request()"), "CI2.send_request() should be called");
-        assertTrue(events.contains("CI2.send_request() throwing NO_PERMISSION"), "CI2 should throw NO_PERMISSION");
-
-        // Verify CI3.send_request() was NOT called
-        assertTrue(events.stream().noneMatch(e -> e.contains("CI3.send_request")),
-            "CI3.send_request() should NOT be called (never pushed to Flow Stack)");
-
-        // Verify receive_exception() flow
-        assertTrue(events.contains("CI1.receive_exception()"), "CI1.receive_exception() should be called (on Flow Stack)");
-
-        // Verify CI2 and CI3 receive_exception() were NOT called
-        assertTrue(events.stream().noneMatch(e -> e.contains("CI2.receive_exception")),
-            "CI2.receive_exception() should NOT be called (interceptor that raised exception)");
-        assertTrue(events.stream().noneMatch(e -> e.contains("CI3.receive_exception")),
-            "CI3.receive_exception() should NOT be called (never pushed to Flow Stack)");
-
-        // Verify no receive_reply() calls (exception path, not normal reply)
-        assertTrue(events.stream().noneMatch(e -> e.contains("receive_reply")),
-            "No receive_reply() should be called on exception path");
-
-        // Verify order: send_request calls happen before receive_exception - Verify the exact sequence
-        assertEquals("CI1.send_request()", events.get(0), "First event should be CI1.send_request()");
-        assertEquals("CI2.send_request()", events.get(1), "Second event should be CI2.send_request()");
-        assertEquals("CI2.send_request() throwing NO_PERMISSION", events.get(2), "Third event should be CI2 throwing exception");
-        assertEquals("CI1.receive_exception()", events.get(3), "Fourth event should be CI1.receive_exception()");
-
-        // Verify total number of events (should be exactly 4)
-        assertEquals(4, events.size(), "Should have exactly 4 events in the execution flow");
+        // Verify expected flow using Mockito InOrder (chained) to check execution order:
+        var order = Mockito.inOrder(CI1, CI2, CI3, SI);
+        order.verify(CI1).send_request(Mockito.any(ClientRequestInfo.class));  // 1. CI1.send_request()
+        order.verify(CI2).send_request(Mockito.any(ClientRequestInfo.class));  // 2. CI2.send_request() throws
+        order.verify(CI1).receive_exception(Mockito.any(ClientRequestInfo.class)); // 3. CI1.receive_exception()
+        order.verifyNoMoreInteractions(); // Verify no other interactions occurred on any of the interceptors
     }
 }

--- a/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
+++ b/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
@@ -36,8 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.omg.CORBA.CompletionStatus.COMPLETED_MAYBE;
-import static org.omg.CORBA.CompletionStatus.COMPLETED_NO;
+import static org.omg.CORBA.CompletionStatus.*;
 import static testify.iiop.annotation.ConfigureOrb.UseWithOrb.InitializerScope.CLIENT;
 
 /**
@@ -135,7 +134,7 @@ public class ClientExceptionFlowTest {
         // Configure CI1 to translate NO_PERMISSION to BAD_INV_ORDER in receive_exception()
         Mockito.doAnswer(invocation -> {
             // Translate to BAD_INV_ORDER (don't verify received exception to avoid assertion errors in mock)
-            throw new org.omg.CORBA.BAD_INV_ORDER("Translated exception from CI1", 0, COMPLETED_NO);
+            throw new org.omg.CORBA.BAD_INV_ORDER("Translated exception from CI1", 0, COMPLETED_MAYBE);
         }).when(CI1).receive_exception(Mockito.any(ClientRequestInfo.class));
 
         // Execute the call and verify BAD_INV_ORDER is thrown (not NO_PERMISSION)
@@ -144,8 +143,17 @@ public class ClientExceptionFlowTest {
         Throwable cause = unwrapException(thrown);
         BAD_INV_ORDER corbaEx = assertInstanceOf(BAD_INV_ORDER.class, cause);
 
-        // Verify completion status
-        assertEquals(COMPLETED_NO, corbaEx.completed, "Exception should have COMPLETED_NO status");
+        // Test the BAD_INV_ORDER has COMPLETED_NO status
+        assertEquals(COMPLETED_NO, corbaEx.completed, "BAD_INV_ORDER should have COMPLETED_NO status");
+
+        // Test the BAD_INV_ORDER has NO_PERMISSION as a suppressed exception
+        Throwable[] suppressed = corbaEx.getSuppressed();
+        assertEquals(1, suppressed.length, "BAD_INV_ORDER should have exactly one suppressed exception");
+        NO_PERMISSION suppressedEx = assertInstanceOf(NO_PERMISSION.class, suppressed[0],
+            "Suppressed exception should be NO_PERMISSION");
+
+        // Test the NO_PERMISSION from CI2 has COMPLETED_NO status - corrected from by send_request exception handling
+        assertEquals(COMPLETED_NO, suppressedEx.completed, "Original NO_PERMISSION from CI2 should have COMPLETED_NO status");
 
         // Verify expected flow using Mockito InOrder to check execution order:
         var order = Mockito.inOrder(CI1, CI2, CI3, SI);

--- a/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
+++ b/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
@@ -19,7 +19,6 @@ package org.omg.PortableInterceptor;
 
 import acme.Echo;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.omg.CORBA.BAD_INV_ORDER;
@@ -38,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.omg.CORBA.CompletionStatus.*;
 import static testify.iiop.annotation.ConfigureOrb.UseWithOrb.InitializerScope.CLIENT;
+import static testify.iiop.annotation.ConfigureOrb.UseWithOrb.InitializerScope.SERVER;
 
 /**
  * Test client-side interceptor exception handling with Flow Stack verification.
@@ -74,6 +74,14 @@ public class ClientExceptionFlowTest {
             assertDoesNotThrow(() -> info.add_client_request_interceptor(CI1));
             assertDoesNotThrow(() -> info.add_client_request_interceptor(CI2));
             assertDoesNotThrow(() -> info.add_client_request_interceptor(CI3));
+        }
+    }
+
+    @UseWithOrb(scope = SERVER)
+    public static class ServerOrbInitializer implements TestORBInitializer {
+        @Override
+        public void pre_init(ORBInitInfo info) {
+            assertDoesNotThrow(() -> info.add_server_request_interceptor(SI));
         }
     }
 
@@ -176,4 +184,55 @@ public class ClientExceptionFlowTest {
         }
         return thrown;
     }
+
+    /**
+     * Exception in receive_reply()
+     * Verifies that when CI2 throws an exception in receive_reply():
+     * - Request completes successfully on server
+     * - receive_reply() called in reverse order: CI3, CI2, CI1
+     * - CI3.receive_reply() executes successfully
+     * - CI2.receive_reply() throws NO_PERMISSION with COMPLETED_YES
+     * - CI1.receive_reply() is NOT called
+     * - receive_exception() called on remaining Flow Stack: CI1
+     * - CI1.receive_exception() called with NO_PERMISSION
+     * - CI2.receive_exception() is NOT called (interceptor that raised exception)
+     * - CI3.receive_exception() is NOT called (already completed successfully)
+     * - Exception reaches client
+     */
+    @Test
+    void testExceptionInReceiveReply(Echo stub) throws Exception {
+        // Configure CI2 to throw NO_PERMISSION in receive_reply()
+        Mockito.doAnswer(invocation -> {
+            // A well-behaved interceptor would throw with COMPLETED_YES in receive_reply(),
+            // but Yoko should also *ensure* the status is COMPLETED_YES.
+            throw new NO_PERMISSION("Test exception in receive_reply", 0, COMPLETED_MAYBE);
+        }).when(CI2).receive_reply(Mockito.any(ClientRequestInfo.class));
+
+        // Execute the call and verify exception is thrown
+        RemoteException remoteEx = assertThrows(RemoteException.class, () -> stub.echo("test"));
+        NO_PERMISSION corbaEx = assertInstanceOf(NO_PERMISSION.class, remoteEx.getCause());
+
+        // Verify completion status - should be COMPLETED_YES since server completed successfully
+        assertEquals(COMPLETED_YES, corbaEx.completed, "Exception should have COMPLETED_YES status");
+
+        // Verify expected flow using Mockito InOrder to check execution order:
+        var order = Mockito.inOrder(CI1, CI2, CI3, SI);
+        // 1. Client send_request() called in forward order
+        order.verify(CI1).send_request(Mockito.any(ClientRequestInfo.class));
+        order.verify(CI2).send_request(Mockito.any(ClientRequestInfo.class));
+        order.verify(CI3).send_request(Mockito.any(ClientRequestInfo.class));
+        // 2. Server interceptor processes request successfully
+        order.verify(SI).receive_request_service_contexts(Mockito.any(ServerRequestInfo.class));
+        order.verify(SI).receive_request(Mockito.any(ServerRequestInfo.class));
+        // 3. Server sends reply successfully
+        order.verify(SI).send_reply(Mockito.any(ServerRequestInfo.class));
+        // 4. Client receive_reply() called in reverse order until CI2 throws
+        order.verify(CI3).receive_reply(Mockito.any(ClientRequestInfo.class));
+        order.verify(CI2).receive_reply(Mockito.any(ClientRequestInfo.class)); // throws here
+        // 5. CI1.receive_reply() is NOT called
+        // 6. receive_exception() called on remaining Flow Stack (only CI1)
+        order.verify(CI1).receive_exception(Mockito.any(ClientRequestInfo.class));
+        order.verifyNoMoreInteractions(); // Verify CI1.receive_reply(), CI2.receive_exception(), CI3.receive_exception(), and SI.send_exception() are NOT called
+    }
+
 }

--- a/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
+++ b/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
@@ -18,14 +18,18 @@
 package org.omg.PortableInterceptor;
 
 import acme.Echo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.omg.CORBA.BAD_INV_ORDER;
 import org.omg.CORBA.NO_PERMISSION;
 import testify.iiop.TestORBInitializer;
 import testify.iiop.annotation.ConfigureOrb.UseWithOrb;
 import testify.iiop.annotation.ConfigureServer;
 import testify.iiop.annotation.ConfigureServer.RemoteImpl;
 
+import java.lang.reflect.UndeclaredThrowableException;
 import java.rmi.RemoteException;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -57,6 +61,12 @@ public class ClientExceptionFlowTest {
     public static final Echo impl = ClientExceptionFlowTest::convertString;
 
     private static String convertString(String s) { return '#' + s + '#'; }
+
+    @AfterEach
+    void resetMocks() {
+        // Reset all mocks after each test to ensure clean state
+        Mockito.reset(CI1, CI2, CI3, SI);
+    }
 
     @UseWithOrb(scope = CLIENT)
     public static class ClientOrbInitializer implements TestORBInitializer {
@@ -102,5 +112,60 @@ public class ClientExceptionFlowTest {
         order.verify(CI2).send_request(Mockito.any(ClientRequestInfo.class));  // 2. CI2.send_request() throws
         order.verify(CI1).receive_exception(Mockito.any(ClientRequestInfo.class)); // 3. CI1.receive_exception()
         order.verifyNoMoreInteractions(); // Verify no other interactions occurred on any of the interceptors
+    }
+
+    /**
+     * Exception Translation in Interceptor Chain
+     * Verifies that an interceptor can translate exceptions in receive_exception():
+     * - CI1.send_request() executes successfully
+     * - CI2.send_request() throws NO_PERMISSION
+     * - CI3.send_request() is NOT called (never pushed to Flow Stack)
+     * - CI1.receive_exception() receives NO_PERMISSION, throws BAD_INV_ORDER
+     * - CI2.receive_exception() is NOT called (interceptor that raised exception)
+     * - CI3.receive_exception() is NOT called (never pushed to Flow Stack)
+     * - Client receives BAD_INV_ORDER (not NO_PERMISSION)
+     */
+    @Test
+    void testExceptionTranslationInInterceptorChain(Echo stub) throws Exception {
+        // Configure CI2 to throw NO_PERMISSION in send_request()
+        Mockito.doAnswer(invocation -> {
+            throw new NO_PERMISSION("Original exception from CI2", 0, COMPLETED_MAYBE);
+        }).when(CI2).send_request(Mockito.any(ClientRequestInfo.class));
+
+        // Configure CI1 to translate NO_PERMISSION to BAD_INV_ORDER in receive_exception()
+        Mockito.doAnswer(invocation -> {
+            // Translate to BAD_INV_ORDER (don't verify received exception to avoid assertion errors in mock)
+            throw new org.omg.CORBA.BAD_INV_ORDER("Translated exception from CI1", 0, COMPLETED_NO);
+        }).when(CI1).receive_exception(Mockito.any(ClientRequestInfo.class));
+
+        // Execute the call and verify BAD_INV_ORDER is thrown (not NO_PERMISSION)
+        Throwable thrown = assertThrows(Throwable.class, () -> stub.echo("should throw"));
+        // Unwrap the exception to get the actual CORBA exception
+        Throwable cause = unwrapException(thrown);
+        BAD_INV_ORDER corbaEx = assertInstanceOf(BAD_INV_ORDER.class, cause);
+
+        // Verify completion status
+        assertEquals(COMPLETED_NO, corbaEx.completed, "Exception should have COMPLETED_NO status");
+
+        // Verify expected flow using Mockito InOrder to check execution order:
+        var order = Mockito.inOrder(CI1, CI2, CI3, SI);
+        order.verify(CI1).send_request(Mockito.any(ClientRequestInfo.class));  // 1. CI1.send_request()
+        order.verify(CI2).send_request(Mockito.any(ClientRequestInfo.class));  // 2. CI2.send_request() throws NO_PERMISSION
+        order.verify(CI1).receive_exception(Mockito.any(ClientRequestInfo.class)); // 3. CI1.receive_exception() translates to BAD_INV_ORDER
+        order.verifyNoMoreInteractions(); // Verify CI2.receive_exception() and CI3 are NOT called
+    }
+
+    /**
+     * Unwraps exception wrappers to get the underlying CORBA exception.
+     * Handles RemoteException and UndeclaredThrowableException wrappers.
+     */
+    private static Throwable unwrapException(Throwable thrown) {
+        if (thrown instanceof RemoteException) {
+            return thrown.getCause();
+        }
+        if (thrown instanceof UndeclaredThrowableException) {
+            return ((UndeclaredThrowableException) thrown).getUndeclaredThrowable();
+        }
+        return thrown;
     }
 }

--- a/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
+++ b/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
@@ -235,4 +235,75 @@ public class ClientExceptionFlowTest {
         order.verifyNoMoreInteractions(); // Verify CI1.receive_reply(), CI2.receive_exception(), CI3.receive_exception(), and SI.send_exception() are NOT called
     }
 
+    /**
+     * Exception in receive_exception()
+     * Objective: Verify exception handling in receive_exception()
+     *
+     * Setup:
+     * - Server throws user exception
+     * - CI2 throws system exception in receive_exception()
+     *
+     * Expected Results:
+     * - Original exception replaced by new exception
+     * - CI1.receive_exception() receives new exception
+     * - Client receives new exception
+     *
+     * Verifies that when CI2 throws an exception in receive_exception():
+     * - CI1.send_request() executes successfully
+     * - CI2.send_request() executes successfully
+     * - CI3.send_request() executes successfully
+     * - Server throws user exception
+     * - receive_exception() called in reverse order: CI3, CI2, CI1
+     * - CI3.receive_exception() executes successfully
+     * - CI2.receive_exception() throws BAD_INV_ORDER (system exception)
+     * - CI1.receive_exception() is called with BAD_INV_ORDER (not original exception)
+     * - Client receives BAD_INV_ORDER (not original exception)
+     */
+    @Test
+    void testExceptionInReceiveException(Echo stub) throws Exception {
+        // Configure server to throw a user exception
+        Mockito.doAnswer(invocation -> {
+            throw new NO_PERMISSION("Original exception from server", 0, COMPLETED_YES);
+        }).when(SI).receive_request(Mockito.any(ServerRequestInfo.class));
+
+        // Configure CI2 to throw BAD_INV_ORDER in receive_exception()
+        Mockito.doAnswer(invocation -> {
+            // CI2 throws a new system exception, replacing the original exception
+            throw new BAD_INV_ORDER("New exception from CI2 in receive_exception", 0, COMPLETED_YES);
+        }).when(CI2).receive_exception(Mockito.any(ClientRequestInfo.class));
+
+        // Execute the call and verify BAD_INV_ORDER is thrown (not NO_PERMISSION)
+        Throwable thrown = assertThrows(Throwable.class, () -> stub.echo("test"));
+        // Unwrap the exception to get the actual CORBA exception
+        Throwable cause = unwrapException(thrown);
+        BAD_INV_ORDER corbaEx = assertInstanceOf(BAD_INV_ORDER.class, cause);
+
+        // Verify completion status - should be COMPLETED_YES since server completed
+        assertEquals(COMPLETED_YES, corbaEx.completed, "Exception should have COMPLETED_YES status");
+
+        // Verify the original NO_PERMISSION is suppressed
+        Throwable[] suppressed = corbaEx.getSuppressed();
+        assertEquals(1, suppressed.length, "BAD_INV_ORDER should have exactly one suppressed exception");
+        NO_PERMISSION suppressedEx = assertInstanceOf(NO_PERMISSION.class, suppressed[0],
+            "Suppressed exception should be the original NO_PERMISSION");
+        assertEquals(COMPLETED_YES, suppressedEx.completed, "Original NO_PERMISSION should have COMPLETED_YES status");
+
+        // Verify expected flow using Mockito InOrder to check execution order:
+        var order = Mockito.inOrder(CI1, CI2, CI3, SI);
+        // 1. Client send_request() called in forward order
+        order.verify(CI1).send_request(Mockito.any(ClientRequestInfo.class));
+        order.verify(CI2).send_request(Mockito.any(ClientRequestInfo.class));
+        order.verify(CI3).send_request(Mockito.any(ClientRequestInfo.class));
+        // 2. Server interceptor processes request
+        order.verify(SI).receive_request_service_contexts(Mockito.any(ServerRequestInfo.class));
+        order.verify(SI).receive_request(Mockito.any(ServerRequestInfo.class)); // throws NO_PERMISSION
+        // 3. Server sends exception
+        order.verify(SI).send_exception(Mockito.any(ServerRequestInfo.class));
+        // 4. Client receive_exception() called in reverse order
+        order.verify(CI3).receive_exception(Mockito.any(ClientRequestInfo.class)); // receives NO_PERMISSION
+        order.verify(CI2).receive_exception(Mockito.any(ClientRequestInfo.class)); // throws BAD_INV_ORDER
+        order.verify(CI1).receive_exception(Mockito.any(ClientRequestInfo.class)); // receives BAD_INV_ORDER
+        order.verifyNoMoreInteractions(); // Verify no other interactions
+    }
+
 }

--- a/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
+++ b/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
@@ -172,20 +172,6 @@ public class ClientExceptionFlowTest {
     }
 
     /**
-     * Unwraps exception wrappers to get the underlying CORBA exception.
-     * Handles RemoteException and UndeclaredThrowableException wrappers.
-     */
-    private static Throwable unwrapException(Throwable thrown) {
-        if (thrown instanceof RemoteException) {
-            return thrown.getCause();
-        }
-        if (thrown instanceof UndeclaredThrowableException) {
-            return ((UndeclaredThrowableException) thrown).getUndeclaredThrowable();
-        }
-        return thrown;
-    }
-
-    /**
      * Exception in receive_reply()
      * Verifies that when CI2 throws an exception in receive_reply():
      * - Request completes successfully on server
@@ -306,4 +292,17 @@ public class ClientExceptionFlowTest {
         order.verifyNoMoreInteractions(); // Verify no other interactions
     }
 
+    /**
+     * Unwraps exception wrappers to get the underlying CORBA exception.
+     * Handles RemoteException and UndeclaredThrowableException wrappers.
+     */
+    private static Throwable unwrapException(Throwable thrown) {
+        if (thrown instanceof RemoteException) {
+            return thrown.getCause();
+        }
+        if (thrown instanceof UndeclaredThrowableException) {
+            return ((UndeclaredThrowableException) thrown).getUndeclaredThrowable();
+        }
+        return thrown;
+    }
 }

--- a/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
+++ b/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientExceptionFlowTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.omg.PortableInterceptor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.omg.CORBA.CompletionStatus;
+import org.omg.CORBA.LocalObject;
+import org.omg.CORBA.NO_PERMISSION;
+import org.omg.CORBA.ORB;
+import org.omg.CORBA.Policy;
+import org.omg.IOP.CodecFactory;
+import org.omg.IOP.CodecFactoryHelper;
+import org.omg.PortableInterceptor.ORBInitInfoPackage.DuplicateName;
+import org.omg.PortableServer.POA;
+import org.omg.PortableServer.POAManager;
+import org.omg.PortableServer.ServantLocator;
+import testify.bus.Bus;
+import testify.bus.key.StringKey;
+import testify.iiop.TestORBInitializer;
+import testify.iiop.annotation.ConfigureOrb;
+import testify.iiop.annotation.ConfigureOrb.UseWithOrb;
+import testify.iiop.annotation.ConfigureServer;
+import testify.iiop.annotation.ConfigureServer.BeforeServer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.yoko.orb.PortableServer.PolicyValue.NON_RETAIN;
+import static org.apache.yoko.orb.PortableServer.PolicyValue.NO_IMPLICIT_ACTIVATION;
+import static org.apache.yoko.orb.PortableServer.PolicyValue.PERSISTENT;
+import static org.apache.yoko.orb.PortableServer.PolicyValue.USER_ID;
+import static org.apache.yoko.orb.PortableServer.PolicyValue.USE_SERVANT_MANAGER;
+import static org.apache.yoko.orb.PortableServer.PolicyValue.create_POA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.omg.CORBA.CompletionStatus.COMPLETED_NO;
+import static org.omg.CORBA.SetOverrideType.ADD_OVERRIDE;
+import static testify.iiop.annotation.ConfigureOrb.UseWithOrb.InitializerScope.CLIENT;
+import static testify.iiop.annotation.ConfigureOrb.UseWithOrb.InitializerScope.SERVER;
+
+/**
+ * Test client-side interceptor exception handling with Flow Stack verification.
+ * Implements TC-CLIENT-001 from the interceptor exception test plan.
+ */
+@ConfigureServer(
+        clientOrb = @ConfigureOrb(props = "yoko.orb.id=client orb"),
+        serverOrb = @ConfigureOrb(props = "yoko.orb.id=server orb")
+)
+public class ClientExceptionFlowTest {
+    private static ClientProxyManager clientProxyManager;
+    private static Bus clientBus;
+    private static ORB clientOrb;
+    private static Policy[] policies;
+    static int serverSlotId;
+
+    enum IorKey implements StringKey {IMPL} //could possibly extract IorKey from PortableInterceptorTest and use a common enum
+
+    /**
+     * Tracks interceptor execution flow for verification.
+     */
+    static class ExecutionTracker {
+        private final List<String> events = Collections.synchronizedList(new ArrayList<>());
+
+        void record(String event) {
+            events.add(event);
+        }
+
+        List<String> getEvents() {
+            return new ArrayList<>(events);
+        }
+
+        void clear() {
+            events.clear();
+        }
+    }
+
+    /**
+     * Test interceptor that records execution and can throw exceptions.
+     */
+    static class TrackingInterceptor extends LocalObject implements ClientRequestInterceptor {
+        private final String name;
+        private final ExecutionTracker tracker;
+        private boolean throwInSendRequest = false;
+        private NO_PERMISSION exceptionToThrow = null;
+
+        TrackingInterceptor(String name, ExecutionTracker tracker) {
+            this.name = name;
+            this.tracker = tracker;
+        }
+
+        void setThrowInSendRequest(NO_PERMISSION exception) {
+            this.throwInSendRequest = true;
+            this.exceptionToThrow = exception;
+        }
+
+        void clearThrow() {
+            this.throwInSendRequest = false;
+            this.exceptionToThrow = null;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public void destroy() {
+            tracker.record(name + ".destroy()");
+        }
+
+        @Override
+        public void send_request(ClientRequestInfo ri) throws ForwardRequest {
+            tracker.record(name + ".send_request()");
+            if (throwInSendRequest && exceptionToThrow != null) {
+                tracker.record(name + ".send_request() throwing " + exceptionToThrow.getClass().getSimpleName());
+                throw exceptionToThrow;
+            }
+        }
+
+        @Override
+        public void send_poll(ClientRequestInfo ri) {
+            tracker.record(name + ".send_poll()");
+        }
+
+        @Override
+        public void receive_reply(ClientRequestInfo ri) {
+            tracker.record(name + ".receive_reply()");
+        }
+
+        @Override
+        public void receive_other(ClientRequestInfo ri) throws ForwardRequest {
+            tracker.record(name + ".receive_other()");
+        }
+
+        @Override
+        public void receive_exception(ClientRequestInfo ri) throws ForwardRequest {
+            tracker.record(name + ".receive_exception()");
+        }
+    }
+
+    @UseWithOrb(scope = CLIENT)
+    public static class ClientOrbInitializer implements TestORBInitializer {
+        @Override
+        public void pre_init(ORBInitInfo info) {
+            clientProxyManager = new ClientProxyManager(info);
+        }
+    }
+
+    @UseWithOrb(scope = SERVER)
+    public static class ServerOrbInitializer implements TestORBInitializer {
+        @Override
+        public void pre_init(ORBInitInfo info) {
+            try {
+                serverSlotId = info.allocate_slot_id();
+                CodecFactory codecFactory = info.codec_factory();
+                info.add_server_request_interceptor(
+                    new ServerTestInterceptor_impl(serverSlotId, codecFactory)
+                );
+            } catch (DuplicateName e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @BeforeServer
+    public static void beforeServer(Bus serverBus, ORB serverOrb, POA rootPoa) throws Exception {
+        assertNotNull(CodecFactoryHelper.narrow(serverOrb.resolve_initial_references("CodecFactory")));
+        POAManager poaMgr = rootPoa.the_POAManager();
+
+        POA persistentPOA = create_POA("persistent", rootPoa, poaMgr,
+                PERSISTENT, USER_ID, USE_SERVANT_MANAGER, NON_RETAIN, NO_IMPLICIT_ACTIVATION);
+
+        // Create servant objects
+        TestInterface_impl impl = new TestInterface_impl(serverOrb, persistentPOA, serverSlotId);
+        TestInterfaceDSI_impl dsiImpl = new TestInterfaceDSI_impl(serverOrb, serverSlotId);
+
+        // Install the servant locator in the POA
+        TestLocator_impl locatorImpl = new TestLocator_impl(serverOrb, impl, dsiImpl);
+        ServantLocator locator = locatorImpl._this(serverOrb);
+        persistentPOA.set_servant_manager(locator);
+
+        // Create and publish the persistent object reference
+        org.omg.CORBA.Object objImpl = persistentPOA.create_reference_with_id(
+            "test".getBytes(),
+            "IDL:TestInterface:1.0"
+        );
+        serverBus.put(IorKey.IMPL, serverOrb.object_to_string(objImpl));
+    }
+
+    @BeforeAll
+    public static void beforeClient(Bus clientBus, ORB clientOrb) {
+        ClientExceptionFlowTest.clientBus = clientBus;
+        ClientExceptionFlowTest.clientOrb = clientOrb;
+        policies = new Policy[0];
+    }
+
+    private TestInterface getTestInterface() {
+        String impl = clientBus.get(IorKey.IMPL);
+        org.omg.CORBA.Object obj = clientOrb.string_to_object(impl)._set_policy_override(policies, ADD_OVERRIDE);
+        return requireNonNull(TestInterfaceHelper.narrow(obj));
+    }
+
+    @AfterEach
+    public void clearClientInterceptors() {
+        clientProxyManager.clearInterceptors();
+    }
+
+    /**
+     * TC-CLIENT-001: Exception in send_request()
+     * Verifies that when CI2 throws an exception in send_request():
+     * - CI1.send_request() executes successfully
+     * - CI2.send_request() throws NO_PERMISSION with COMPLETED_NO
+     * - CI3.send_request() is NOT called (never pushed to Flow Stack)
+     * - CI1.receive_exception() is called (only interceptors on Flow Stack)
+     * - CI2.receive_exception() is NOT called (interceptor that raised exception)
+     * - CI3.receive_exception() is NOT called (never pushed to Flow Stack)
+     * - Exception reaches client application
+     * - No network request is sent
+     */
+    @Test
+    void testExceptionInSendRequest() {
+        ExecutionTracker tracker = new ExecutionTracker();
+
+        // Create three interceptors
+        TrackingInterceptor ci1 = new TrackingInterceptor("CI1", tracker);
+        TrackingInterceptor ci2 = new TrackingInterceptor("CI2", tracker);
+        TrackingInterceptor ci3 = new TrackingInterceptor("CI3", tracker);
+
+        // Configure CI2 to throw NO_PERMISSION in send_request()
+        NO_PERMISSION expectedException = new NO_PERMISSION("Test exception", 0, COMPLETED_NO);
+        ci2.setThrowInSendRequest(expectedException);
+
+        // Register interceptors
+        clientProxyManager.setInterceptor(0, ci1);
+        clientProxyManager.setInterceptor(1, ci2);
+        clientProxyManager.setInterceptor(2, ci3);
+
+        TestInterface ti = getTestInterface();
+
+        // Execute the call and verify exception is thrown
+        NO_PERMISSION thrownException = assertThrows(NO_PERMISSION.class, ti::noargs);
+
+        // Verify completion status
+        assertEquals(COMPLETED_NO, thrownException.completed,
+            "Exception should have COMPLETED_NO status");
+
+        // Verify execution flow
+        List<String> events = tracker.getEvents();
+
+        // Expected flow:
+        // 1. CI1.send_request() - executes successfully
+        // 2. CI2.send_request() - throws exception
+        // 3. CI3.send_request() - NOT called (never pushed to Flow Stack)
+        // 4. CI1.receive_exception() - called (on Flow Stack)
+        // 5. CI2.receive_exception() - NOT called (threw the exception)
+        // 6. CI3.receive_exception() - NOT called (never on Flow Stack)
+
+        assertTrue(events.contains("CI1.send_request()"), "CI1.send_request() should be called");
+        assertTrue(events.contains("CI2.send_request()"), "CI2.send_request() should be called");
+        assertTrue(events.contains("CI2.send_request() throwing NO_PERMISSION"), "CI2 should throw NO_PERMISSION");
+
+        // Verify CI3.send_request() was NOT called
+        assertTrue(events.stream().noneMatch(e -> e.contains("CI3.send_request")),
+            "CI3.send_request() should NOT be called (never pushed to Flow Stack)");
+
+        // Verify receive_exception() flow
+        assertTrue(events.contains("CI1.receive_exception()"), "CI1.receive_exception() should be called (on Flow Stack)");
+
+        // Verify CI2 and CI3 receive_exception() were NOT called
+        assertTrue(events.stream().noneMatch(e -> e.contains("CI2.receive_exception")),
+            "CI2.receive_exception() should NOT be called (interceptor that raised exception)");
+        assertTrue(events.stream().noneMatch(e -> e.contains("CI3.receive_exception")),
+            "CI3.receive_exception() should NOT be called (never pushed to Flow Stack)");
+
+        // Verify no receive_reply() calls (exception path, not normal reply)
+        assertTrue(events.stream().noneMatch(e -> e.contains("receive_reply")),
+            "No receive_reply() should be called on exception path");
+
+        // Verify order: send_request calls happen before receive_exception - Verify the exact sequence
+        assertEquals("CI1.send_request()", events.get(0), "First event should be CI1.send_request()");
+        assertEquals("CI2.send_request()", events.get(1), "Second event should be CI2.send_request()");
+        assertEquals("CI2.send_request() throwing NO_PERMISSION", events.get(2), "Third event should be CI2 throwing exception");
+        assertEquals("CI1.receive_exception()", events.get(3), "Fourth event should be CI1.receive_exception()");
+
+        // Verify total number of events (should be exactly 4)
+        assertEquals(4, events.size(), "Should have exactly 4 events in the execution flow");
+    }
+}

--- a/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientServerMethodsSupportTest.java
+++ b/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientServerMethodsSupportTest.java
@@ -1,0 +1,601 @@
+package org.omg.PortableInterceptor;
+
+import acme.Echo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.omg.CORBA.BAD_INV_ORDER;
+import org.omg.CORBA.NO_PERMISSION;
+import testify.iiop.TestORBInitializer;
+import testify.iiop.annotation.ConfigureOrb;
+import testify.iiop.annotation.ConfigureServer;
+import testify.iiop.annotation.ConfigureServer.RemoteImpl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.omg.CORBA.CompletionStatus.COMPLETED_YES;
+import static testify.iiop.annotation.ConfigureOrb.UseWithOrb.InitializerScope.CLIENT;
+import static testify.iiop.annotation.ConfigureOrb.UseWithOrb.InitializerScope.SERVER;
+
+@ConfigureServer
+public class ClientServerMethodsSupportTest {
+
+    private static final ClientRequestInterceptor CI1 = Mockito.mock(ClientRequestInterceptor.class, "CI1");
+    private static final ClientRequestInterceptor CI2 = Mockito.mock(ClientRequestInterceptor.class, "CI2");
+    private static final ClientRequestInterceptor CI3 = Mockito.mock(ClientRequestInterceptor.class, "CI3");
+    private static final ServerRequestInterceptor SI = Mockito.mock(ServerRequestInterceptor.class, "SI");
+
+    static {
+        Mockito.when(CI1.name()).thenReturn("CI1");
+        Mockito.when(CI2.name()).thenReturn("CI2");
+        Mockito.when(CI3.name()).thenReturn("CI3");
+        Mockito.when(SI.name()).thenReturn("SI");
+    }
+
+    @RemoteImpl
+    public static final Echo impl = ClientServerMethodsSupportTest::convertString;
+
+    private static String convertString(String s) { return '#' + s + '#'; }
+
+    @AfterEach
+    void resetMocks() {
+        // Reset all mocks after each test to ensure clean state
+        Mockito.reset(CI1, CI2, CI3, SI);
+    }
+
+    @ConfigureOrb.UseWithOrb(scope = CLIENT)
+    public static class ClientOrbInitializer implements TestORBInitializer {
+        @Override
+        public void pre_init(ORBInitInfo info) {
+            assertDoesNotThrow(() -> info.add_client_request_interceptor(CI1));
+            assertDoesNotThrow(() -> info.add_client_request_interceptor(CI2));
+            assertDoesNotThrow(() -> info.add_client_request_interceptor(CI3));
+        }
+    }
+
+    @ConfigureOrb.UseWithOrb(scope = SERVER)
+    public static class ServerOrbInitializer implements TestORBInitializer {
+        @Override
+        public void pre_init(ORBInitInfo info) {
+            assertDoesNotThrow(() -> info.add_server_request_interceptor(SI));
+        }
+    }
+
+    /**
+     * Comprehensive test of ClientRequestInfo method availability at different interception points.
+     *
+     * Tests what methods are supported at each interception point:
+     * - send_request: Before the request is sent to the server
+     * - receive_reply: After receiving a successful reply
+     * - receive_exception: After receiving an exception
+     *
+     * Expected behaviors:
+     * - Fully supported: Method succeeds and returns valid data
+     * - BAD_INV_ORDER: Method is defined but not available at this point (error path covered)
+     * - NO_RESOURCES or other: Method not supported at all
+     */
+    @Test
+    void testClientRequestInfoMethodAvailabilityAtInterceptionPoints(Echo stub) throws Exception {
+        final StringBuilder report = new StringBuilder();
+
+        // Configure CI1 to test method availability at send_request
+        Mockito.doAnswer(invocation -> {
+            ClientRequestInfo ri = invocation.getArgument(0);
+            report.append("\n=== send_request() interception point ===\n");
+            testMethodAvailability(ri, report);
+            return null;
+        }).when(CI1).send_request(Mockito.any(ClientRequestInfo.class));
+
+        // Configure CI1 to test method availability at receive_reply
+        Mockito.doAnswer(invocation -> {
+            ClientRequestInfo ri = invocation.getArgument(0);
+            report.append("\n=== receive_reply() interception point ===\n");
+            testMethodAvailability(ri, report);
+            return null;
+        }).when(CI1).receive_reply(Mockito.any(ClientRequestInfo.class));
+
+        // Configure server to throw exception to test receive_exception
+        Mockito.doAnswer(invocation -> {
+            throw new NO_PERMISSION("Test exception for receive_exception", 0, COMPLETED_YES);
+        }).when(SI).receive_request(Mockito.any(ServerRequestInfo.class));
+
+        // Configure CI1 to test method availability at receive_exception
+        Mockito.doAnswer(invocation -> {
+            ClientRequestInfo ri = invocation.getArgument(0);
+            report.append("\n=== receive_exception() interception point ===\n");
+            testMethodAvailability(ri, report);
+            return null;
+        }).when(CI1).receive_exception(Mockito.any(ClientRequestInfo.class));
+
+        // Execute the call
+        try {
+            stub.echo("test");
+        } catch (Exception e) {
+            // Expected - server throws exception
+        }
+
+        // Print the comprehensive report
+        System.out.println("\n" + "=".repeat(80));
+        System.out.println("CLIENT REQUEST INFO METHOD AVAILABILITY REPORT");
+        System.out.println("=".repeat(80));
+        System.out.println(report);
+        System.out.println("=".repeat(80));
+
+        // Verify that the report contains all interception points
+        String reportStr = report.toString();
+        assertTrue(reportStr.contains("send_request() interception point"), "Report should contain send_request section");
+        assertTrue(reportStr.contains("receive_exception() interception point"), "Report should contain receive_exception section");
+    }
+
+    /**
+     * Test ClientRequestInfo method availability at receive_reply interception point.
+     *
+     * This test complements testClientRequestInfoMethodAvailabilityAtInterceptionPoints
+     * by testing the receive_reply interception point when the call succeeds.
+     * Also tests send_poll and receive_other interception points defined in
+     * ClientRequestInterceptorOperations.java.
+     */
+    @Test
+    void testClientRequestInfoMethodAvailabilityAtReceiveReply(Echo stub) throws Exception {
+        final StringBuilder report = new StringBuilder();
+
+        // Configure CI1 to test method availability at send_request
+        Mockito.doAnswer(invocation -> {
+            ClientRequestInfo ri = invocation.getArgument(0);
+            report.append("\n=== send_request() interception point ===\n");
+            testMethodAvailability(ri, report);
+            return null;
+        }).when(CI1).send_request(Mockito.any(ClientRequestInfo.class));
+
+        // Configure CI1 to test method availability at send_poll
+        Mockito.doAnswer(invocation -> {
+            ClientRequestInfo ri = invocation.getArgument(0);
+            report.append("\n=== send_poll() interception point ===\n");
+            testMethodAvailability(ri, report);
+            return null;
+        }).when(CI1).send_poll(Mockito.any(ClientRequestInfo.class));
+
+        // Configure CI1 to test method availability at receive_reply
+        Mockito.doAnswer(invocation -> {
+            ClientRequestInfo ri = invocation.getArgument(0);
+            report.append("\n=== receive_reply() interception point ===\n");
+            testMethodAvailability(ri, report);
+            return null;
+        }).when(CI1).receive_reply(Mockito.any(ClientRequestInfo.class));
+
+        // Configure CI1 to test method availability at receive_other
+        Mockito.doAnswer(invocation -> {
+            ClientRequestInfo ri = invocation.getArgument(0);
+            report.append("\n=== receive_other() interception point ===\n");
+            testMethodAvailability(ri, report);
+            return null;
+        }).when(CI1).receive_other(Mockito.any(ClientRequestInfo.class));
+
+        // Execute a successful call - this will trigger send_request and receive_reply
+        String result = stub.echo("test");
+        assertEquals("#test#", result, "Echo should succeed");
+
+        // Print the comprehensive report
+        System.out.println("\n" + "=".repeat(80));
+        System.out.println("CLIENT REQUEST INFO METHOD AVAILABILITY REPORT (SUCCESSFUL REPLY)");
+        System.out.println("=".repeat(80));
+        System.out.println(report.toString());
+        System.out.println("=".repeat(80));
+
+        // Verify that the report contains all interception points that were triggered
+        String reportStr = report.toString();
+        assertEquals(true, reportStr.contains("send_request() interception point"),
+                "Report should contain send_request section");
+        assertEquals(true, reportStr.contains("receive_reply() interception point"),
+                "Report should contain receive_reply section");
+        
+        // Note: send_poll and receive_other may not be triggered in a normal synchronous call
+        // but we've configured them to be tested if they are invoked
+    }
+
+    /**
+     * Comprehensive test of ServerRequestInfo method availability at different interception points.
+     *
+     * Tests what methods are supported at each server-side interception point:
+     * - receive_request_service_contexts: After receiving request but before unmarshaling
+     * - receive_request: After unmarshaling arguments
+     * - send_reply: Before sending successful reply
+     * - send_exception: Before sending exception reply
+     *
+     * Expected behaviors:
+     * - Fully supported: Method succeeds and returns valid data
+     * - BAD_INV_ORDER: Method is defined but not available at this point (error path covered)
+     * - NO_RESOURCES or other: Method not supported at all
+     */
+    @Test
+    void testServerRequestInfoMethodAvailabilityAtInterceptionPoints(Echo stub) throws Exception {
+        final StringBuilder report = new StringBuilder();
+
+        // Configure SI to test method availability at receive_request_service_contexts
+        Mockito.doAnswer(invocation -> {
+            ServerRequestInfo ri = invocation.getArgument(0);
+            report.append("\n=== receive_request_service_contexts() interception point ===\n");
+            testServerMethodAvailability(ri, "receive_request_service_contexts", report);
+            return null;
+        }).when(SI).receive_request_service_contexts(Mockito.any(ServerRequestInfo.class));
+
+        // Configure SI to test method availability at receive_request
+        Mockito.doAnswer(invocation -> {
+            ServerRequestInfo ri = invocation.getArgument(0);
+            report.append("\n=== receive_request() interception point ===\n");
+            testServerMethodAvailability(ri, "receive_request", report);
+            return null;
+        }).when(SI).receive_request(Mockito.any(ServerRequestInfo.class));
+
+        // Configure SI to test method availability at send_reply
+        Mockito.doAnswer(invocation -> {
+            ServerRequestInfo ri = invocation.getArgument(0);
+            report.append("\n=== send_reply() interception point ===\n");
+            testServerMethodAvailability(ri, "send_reply", report);
+            return null;
+        }).when(SI).send_reply(Mockito.any(ServerRequestInfo.class));
+
+        // Execute a successful call
+        String result = stub.echo("test");
+        assertEquals("#test#", result, "Echo should succeed");
+
+        // Print the comprehensive report
+        System.out.println("\n" + "=".repeat(80));
+        System.out.println("SERVER REQUEST INFO METHOD AVAILABILITY REPORT (SUCCESSFUL CALL)");
+        System.out.println("=".repeat(80));
+        System.out.println(report.toString());
+        System.out.println("=".repeat(80));
+
+        // Verify that the report contains all interception points
+        String reportStr = report.toString();
+        assertEquals(true, reportStr.contains("receive_request_service_contexts() interception point"),
+                "Report should contain receive_request_service_contexts section");
+        assertEquals(true, reportStr.contains("receive_request() interception point"),
+                "Report should contain receive_request section");
+        assertEquals(true, reportStr.contains("send_reply() interception point"),
+                "Report should contain send_reply section");
+    }
+
+    /**
+     * Test ServerRequestInfo method availability at send_exception interception point.
+     */
+    @Test
+    void testServerRequestInfoMethodAvailabilityAtSendException(Echo stub) throws Exception {
+        final StringBuilder report = new StringBuilder();
+
+        // Configure SI to test method availability at receive_request_service_contexts
+        Mockito.doAnswer(invocation -> {
+            ServerRequestInfo ri = invocation.getArgument(0);
+            report.append("\n=== receive_request_service_contexts() interception point ===\n");
+            testServerMethodAvailability(ri, "receive_request_service_contexts", report);
+            return null;
+        }).when(SI).receive_request_service_contexts(Mockito.any(ServerRequestInfo.class));
+
+        // Configure SI to throw exception at receive_request
+        Mockito.doAnswer(invocation -> {
+            ServerRequestInfo ri = invocation.getArgument(0);
+            report.append("\n=== receive_request() interception point ===\n");
+            testServerMethodAvailability(ri, "receive_request", report);
+            throw new NO_PERMISSION("Test exception from server", 0, COMPLETED_YES);
+        }).when(SI).receive_request(Mockito.any(ServerRequestInfo.class));
+
+        // Configure SI to test method availability at send_exception
+        Mockito.doAnswer(invocation -> {
+            ServerRequestInfo ri = invocation.getArgument(0);
+            report.append("\n=== send_exception() interception point ===\n");
+            testServerMethodAvailability(ri, "send_exception", report);
+            return null;
+        }).when(SI).send_exception(Mockito.any(ServerRequestInfo.class));
+
+        // Execute the call - expect exception
+        try {
+            stub.echo("test");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        // Print the comprehensive report
+        System.out.println("\n" + "=".repeat(80));
+        System.out.println("SERVER REQUEST INFO METHOD AVAILABILITY REPORT (EXCEPTION CASE)");
+        System.out.println("=".repeat(80));
+        System.out.println(report.toString());
+        System.out.println("=".repeat(80));
+
+        // Verify that the report contains all interception points
+        String reportStr = report.toString();
+        assertEquals(true, reportStr.contains("receive_request_service_contexts() interception point"),
+                "Report should contain receive_request_service_contexts section");
+        assertEquals(true, reportStr.contains("receive_request() interception point"),
+                "Report should contain receive_request section");
+        assertEquals(true, reportStr.contains("send_exception() interception point"),
+                "Report should contain send_exception section");
+    }
+
+    /**
+     * Helper method to test availability of ServerRequestInfo methods at a specific interception point.
+     */
+    private static void testServerMethodAvailability(ServerRequestInfo ri, String interceptionPoint, StringBuilder report) {
+        // Test RequestInfo methods (inherited)
+        testMethod(report, "request_id()", () -> {
+            int id = ri.request_id();
+            return "SUCCESS: " + id;
+        });
+
+        testMethod(report, "operation()", () -> {
+            String op = ri.operation();
+            return "SUCCESS: " + op;
+        });
+
+        testMethod(report, "arguments()", () -> {
+            org.omg.Dynamic.Parameter[] args = ri.arguments();
+            return "SUCCESS: " + args.length + " arguments";
+        });
+
+        testMethod(report, "exceptions()", () -> {
+            org.omg.CORBA.TypeCode[] exs = ri.exceptions();
+            return "SUCCESS: " + exs.length + " exceptions";
+        });
+
+        testMethod(report, "contexts()", () -> {
+            String[] ctxs = ri.contexts();
+            return "SUCCESS: " + ctxs.length + " contexts";
+        });
+
+        testMethod(report, "operation_context()", () -> {
+            String[] opCtx = ri.operation_context();
+            return "SUCCESS: " + opCtx.length + " operation contexts";
+        });
+
+        testMethod(report, "result()", () -> {
+            org.omg.CORBA.Any res = ri.result();
+            return "SUCCESS: result available";
+        });
+
+        testMethod(report, "response_expected()", () -> {
+            boolean expected = ri.response_expected();
+            return "SUCCESS: " + expected;
+        });
+
+        testMethod(report, "sync_scope()", () -> {
+            short scope = ri.sync_scope();
+            return "SUCCESS: " + scope;
+        });
+
+        testMethod(report, "reply_status()", () -> {
+            short status = ri.reply_status();
+            return "SUCCESS: " + status;
+        });
+
+        testMethod(report, "forward_reference()", () -> {
+            org.omg.CORBA.Object ref = ri.forward_reference();
+            return "SUCCESS: forward reference available";
+        });
+
+        testMethod(report, "get_slot(0)", () -> {
+            org.omg.CORBA.Any slot = ri.get_slot(0);
+            return "SUCCESS: slot available";
+        });
+
+        testMethod(report, "get_request_service_context(0)", () -> {
+            org.omg.IOP.ServiceContext ctx = ri.get_request_service_context(0);
+            return "SUCCESS: service context available";
+        });
+
+        testMethod(report, "get_reply_service_context(0)", () -> {
+            org.omg.IOP.ServiceContext ctx = ri.get_reply_service_context(0);
+            return "SUCCESS: reply service context available";
+        });
+
+        // Test ServerRequestInfo-specific methods
+        testMethod(report, "sending_exception()", () -> {
+            org.omg.CORBA.Any ex = ri.sending_exception();
+            return "SUCCESS: sending exception available";
+        });
+
+        testMethod(report, "object_id()", () -> {
+            byte[] id = ri.object_id();
+            return "SUCCESS: object_id length=" + id.length;
+        });
+
+        testMethod(report, "adapter_id()", () -> {
+            byte[] id = ri.adapter_id();
+            return "SUCCESS: adapter_id length=" + id.length;
+        });
+
+        testMethod(report, "target_most_derived_interface()", () -> {
+            String iface = ri.target_most_derived_interface();
+            return "SUCCESS: " + iface;
+        });
+
+        testMethod(report, "server_id()", () -> {
+            String id = ri.server_id();
+            return "SUCCESS: " + id;
+        });
+
+        testMethod(report, "orb_id()", () -> {
+            String id = ri.orb_id();
+            return "SUCCESS: " + id;
+        });
+
+        testMethod(report, "adapter_name()", () -> {
+            String[] name = ri.adapter_name();
+            return "SUCCESS: " + name.length + " adapter name components";
+        });
+
+        testMethod(report, "get_server_policy(0)", () -> {
+            org.omg.CORBA.Policy policy = ri.get_server_policy(0);
+            return "SUCCESS: server policy available";
+        });
+
+        testMethod(report, "set_slot(0, any)", () -> {
+            // Note: We can't easily create an Any here without access to the proper ORB
+            // So we'll just test with a null Any to see if the method is callable
+            try {
+                ri.set_slot(0, null);
+                return "SUCCESS: slot set (with null)";
+            } catch (NullPointerException e) {
+                // Expected - but at least we know the method is callable
+                return "SUCCESS: method callable (NPE on null Any is expected)";
+            }
+        });
+
+        testMethod(report, "target_is_a(\"IDL:acme/Echo:1.0\")", () -> {
+            boolean result = ri.target_is_a("IDL:acme/Echo:1.0");
+            return "SUCCESS: " + result;
+        });
+
+        testMethod(report, "add_reply_service_context()", () -> {
+            org.omg.IOP.ServiceContext ctx = new org.omg.IOP.ServiceContext(999, new byte[]{1, 2, 3});
+            ri.add_reply_service_context(ctx, false);
+            return "SUCCESS: reply service context added";
+        });
+    }
+
+    /**
+     * Helper method to test availability of ClientRequestInfo methods at a specific interception point.
+     */
+    private static void testMethodAvailability(ClientRequestInfo ri, StringBuilder report) {
+        // Test RequestInfo methods (inherited)
+        testMethod(report, "request_id()", () -> {
+            int id = ri.request_id();
+            return "SUCCESS: " + id;
+        });
+
+        testMethod(report, "operation()", () -> {
+            String op = ri.operation();
+            return "SUCCESS: " + op;
+        });
+
+        testMethod(report, "arguments()", () -> {
+            org.omg.Dynamic.Parameter[] args = ri.arguments();
+            return "SUCCESS: " + args.length + " arguments";
+        });
+
+        testMethod(report, "exceptions()", () -> {
+            org.omg.CORBA.TypeCode[] exs = ri.exceptions();
+            return "SUCCESS: " + exs.length + " exceptions";
+        });
+
+        testMethod(report, "contexts()", () -> {
+            String[] ctxs = ri.contexts();
+            return "SUCCESS: " + ctxs.length + " contexts";
+        });
+
+        testMethod(report, "operation_context()", () -> {
+            String[] opCtx = ri.operation_context();
+            return "SUCCESS: " + opCtx.length + " operation contexts";
+        });
+
+        testMethod(report, "result()", () -> {
+            org.omg.CORBA.Any res = ri.result();
+            return "SUCCESS: result available";
+        });
+
+        testMethod(report, "response_expected()", () -> {
+            boolean expected = ri.response_expected();
+            return "SUCCESS: " + expected;
+        });
+
+        testMethod(report, "sync_scope()", () -> {
+            short scope = ri.sync_scope();
+            return "SUCCESS: " + scope;
+        });
+
+        testMethod(report, "reply_status()", () -> {
+            short status = ri.reply_status();
+            return "SUCCESS: " + status;
+        });
+
+        testMethod(report, "forward_reference()", () -> {
+            org.omg.CORBA.Object ref = ri.forward_reference();
+            return "SUCCESS: forward reference available";
+        });
+
+        testMethod(report, "get_slot(0)", () -> {
+            org.omg.CORBA.Any slot = ri.get_slot(0);
+            return "SUCCESS: slot available";
+        });
+
+        testMethod(report, "get_request_service_context(0)", () -> {
+            org.omg.IOP.ServiceContext ctx = ri.get_request_service_context(0);
+            return "SUCCESS: service context available";
+        });
+
+        testMethod(report, "get_reply_service_context(0)", () -> {
+            org.omg.IOP.ServiceContext ctx = ri.get_reply_service_context(0);
+            return "SUCCESS: reply service context available";
+        });
+
+        // Test ClientRequestInfo-specific methods
+        testMethod(report, "target()", () -> {
+            org.omg.CORBA.Object target = ri.target();
+            return "SUCCESS: target available";
+        });
+
+        testMethod(report, "effective_target()", () -> {
+            org.omg.CORBA.Object target = ri.effective_target();
+            return "SUCCESS: effective target available";
+        });
+
+        testMethod(report, "effective_profile()", () -> {
+            org.omg.IOP.TaggedProfile profile = ri.effective_profile();
+            return "SUCCESS: effective profile available";
+        });
+
+        testMethod(report, "received_exception()", () -> {
+            org.omg.CORBA.Any ex = ri.received_exception();
+            return "SUCCESS: received exception available";
+        });
+
+        testMethod(report, "received_exception_id()", () -> {
+            String id = ri.received_exception_id();
+            return "SUCCESS: " + id;
+        });
+
+        testMethod(report, "get_effective_component(0)", () -> {
+            org.omg.IOP.TaggedComponent comp = ri.get_effective_component(0);
+            return "SUCCESS: effective component available";
+        });
+
+        testMethod(report, "get_effective_components(0)", () -> {
+            org.omg.IOP.TaggedComponent[] comps = ri.get_effective_components(0);
+            return "SUCCESS: " + comps.length + " effective components";
+        });
+
+        testMethod(report, "get_request_policy(0)", () -> {
+            org.omg.CORBA.Policy policy = ri.get_request_policy(0);
+            return "SUCCESS: request policy available";
+        });
+
+        testMethod(report, "add_request_service_context()", () -> {
+            // Create a dummy service context
+            org.omg.IOP.ServiceContext ctx = new org.omg.IOP.ServiceContext(999, new byte[]{1, 2, 3});
+            ri.add_request_service_context(ctx, false);
+            return "SUCCESS: service context added";
+        });
+    }
+
+    /**
+     * Helper to test a single method and categorize the result.
+     */
+    private static void testMethod(StringBuilder report, String methodName, ThrowingSupplier<String> test) {
+        try {
+            String result = test.get();
+            report.append(String.format("  ✓ %-40s %s\n", methodName, result));
+        } catch (BAD_INV_ORDER e) {
+            report.append(String.format("  ⚠ %-40s BAD_INV_ORDER (supported with BAD_INV_ORDER at this point)\n", methodName));
+        } catch (org.omg.CORBA.NO_RESOURCES e) {
+            if (e.getMessage() != null && e.getMessage().contains("arguments unavailable")) {
+                report.append(String.format("  ✗ %-40s NO_RESOURCES: %s\n", methodName, "NOT SUPPORTED - arguments unavailable"));
+            } else {
+                report.append(String.format("  ✗ %-40s NO_RESOURCES: %s\n", methodName, e.getMessage()));
+            }
+        } catch (Exception e) {
+            report.append(String.format("  ✗ %-40s %s: %s\n", methodName, e.getClass().getSimpleName(), e.getMessage()));
+        }
+    }
+
+    @FunctionalInterface
+    interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+}

--- a/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientServerMethodsSupportTest.java
+++ b/yoko-verify/src/test/java-testify/org/omg/PortableInterceptor/ClientServerMethodsSupportTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.omg.PortableInterceptor;
 
 import acme.Echo;


### PR DESCRIPTION
Add ClientExceptionFlowTest to verify CORBA Portable Interceptor Flow Stack behavior when exceptions occur during send_request(). Implements TC-CLIENT-001 from the interceptor exception test plan.

Verifies that when an interceptor throws an exception:
- Only interceptors already on the Flow Stack receive receive_exception()
- The throwing interceptor does not receive receive_exception()
- Interceptors never pushed to the Flow Stack are not invoked

Includes ExecutionTracker and TrackingInterceptor helper classes for comprehensive execution flow verification.