### PR TITLE
test(framework): add Yoko interop test support

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 IBM Corporation and others.
+# Copyright 2026 IBM Corporation and others.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ jobs:
     - name: Testify unit tests
       run: ./gradlew testify:test
     - name: Testify-IIOP unit-tests
-      run: ./gradlew testify-iiop:test
+      run: ./gradlew testify-iiop:test -Dtest.excludeTags=interop
     - name: Yoko OSGi unit tests
       run: ./gradlew yoko-osgi:test
     - name: Yoko util unit-tests
@@ -57,7 +57,7 @@ jobs:
     - name: Yoko core unit tests
       run: ./gradlew yoko-core:test
     - name: Yoko verification tests
-      run: ./gradlew yoko-verify:test
+      run: ./gradlew yoko-verify:test -Dtest.excludeTags=interop
     - name: Aggregate test report
       run: ./gradlew testReport -x test
     - name: Upload test reports

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ build
 
 # Bob Shell worktrees
 .bob/
+
+# ignore interop test worktrees
+worktrees

--- a/build-interop.gradle
+++ b/build-interop.gradle
@@ -1,0 +1,489 @@
+/*
+ * Copyright 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Yoko Interoperability Testing Build Configuration
+ * 
+ * This file contains Gradle tasks for managing Yoko versions for interop testing.
+ * It supports two approaches:
+ * 1. fetchYokoVersion - Download pre-built JARs from GitHub releases
+ * 2. buildYokoVersion - Build a specific version from source using git worktrees
+ * 
+ * Both approaches automatically fetch transitive dependencies from Maven.
+ */
+
+// Task to build and cache a specific Yoko version for interop testing
+task buildYokoVersion {
+    description = 'Build and cache a specific Yoko version for interop testing'
+    group = 'interop'
+
+    doLast {
+        def version = project.findProperty('yokoVersion')
+        if (!version) {
+            throw new GradleException("Please specify -PyokoVersion=<version> (e.g., -PyokoVersion=1.5.3)")
+        }
+
+        def tag = "v${version}"
+        def cacheDir = file("${System.getProperty('user.home')}/.yoko-interop-cache/${version}")
+        def worktreeDir = file("${projectDir}/worktrees/${version}")
+
+        // Check if already cached
+        if (cacheDir.exists() && cacheDir.list().length > 0) {
+            println "Version ${version} is already cached in ${cacheDir}"
+            return
+        }
+
+        println "Building Yoko version ${version} (tag: ${tag})"
+
+        // Create worktree if it doesn't exist
+        if (!worktreeDir.exists()) {
+            println "Creating worktree for ${tag} in ${worktreeDir}"
+            exec {
+                commandLine 'git', 'worktree', 'add', worktreeDir.absolutePath, tag
+            }
+        } else {
+            println "Worktree already exists at ${worktreeDir}"
+            // Ensure it's on the correct tag
+            exec {
+                workingDir worktreeDir
+                commandLine 'git', 'checkout', tag
+            }
+        }
+
+        // Build the version (skip tests for speed)
+        println "Building Yoko ${version}..."
+        exec {
+            workingDir worktreeDir
+            commandLine './gradlew', 'build', '-x', 'test', '--no-daemon'
+        }
+
+        // Create cache directory
+        cacheDir.mkdirs()
+
+        // Collect all JARs from subprojects
+        println "Collecting JARs to ${cacheDir}..."
+        def jarCount = 0
+
+        // Copy only yoko-* JARs (not testify, test-osgi, artifact, etc.)
+        fileTree(worktreeDir) {
+            include '**/build/libs/yoko-*.jar'
+            exclude '**/build/libs/*-javadoc.jar'
+            exclude '**/build/libs/*-sources.jar'
+        }.each { jarFile ->
+            copy {
+                from jarFile
+                into cacheDir
+            }
+            println "  Copied: ${jarFile.name}"
+            jarCount++
+        }
+
+        // Parse POMs and fetch transitive dependencies (same logic as fetchYokoVersion)
+        println "Fetching transitive dependencies..."
+        def dependencies = [] as Set
+        fileTree(cacheDir) {
+            include '*.jar'
+        }.each { jarFile ->
+            def pomPath = "META-INF/maven/io.openliberty.yoko/${jarFile.name.replaceAll(/-\d+.*\.jar$/, '')}/pom.xml"
+            try {
+                def pomContent = new java.util.zip.ZipFile(jarFile).getInputStream(
+                    new java.util.zip.ZipEntry(pomPath)
+                ).text
+                def pom = new XmlSlurper().parseText(pomContent)
+                pom.dependencies.dependency.each { dep ->
+                    def groupId = dep.groupId.text()
+                    def artifactId = dep.artifactId.text()
+                    def depVersion = dep.version.text()
+                    // Only fetch external dependencies (not Yoko modules)
+                    if (!groupId.startsWith('io.openliberty.yoko')) {
+                        dependencies.add("${groupId}:${artifactId}:${depVersion}")
+                    }
+                }
+            } catch (Exception e) {
+                // POM not found or parse error - skip
+            }
+        }
+
+        // Helper function to fetch a dependency and its transitives recursively
+        def fetchDependency
+        fetchDependency = { String depCoord, Set<String> processed, File m2Repo ->
+            if (processed.contains(depCoord)) return
+            processed.add(depCoord)
+            
+            try {
+                def parts = depCoord.split(':')
+                def group = parts[0]
+                def name = parts[1]
+                def depVersion = parts[2]
+                
+                def jarName = "${name}-${depVersion}.jar"
+                def destFile = new File(cacheDir, jarName)
+                
+                if (destFile.exists()) {
+                    println "  Already cached: ${jarName}"
+                    jarCount++
+                } else {
+                    // Check local Maven cache first
+                    def localPath = new File(m2Repo, "${group.replace('.', '/')}/${name}/${depVersion}/${jarName}")
+                    if (localPath.exists()) {
+                        println "  Copying from local Maven cache: ${jarName}"
+                        copy {
+                            from localPath
+                            into cacheDir
+                        }
+                        jarCount++
+                    } else {
+                        // Download from Maven Central
+                        def groupPath = group.replace('.', '/')
+                        def url = "https://repo1.maven.org/maven2/${groupPath}/${name}/${depVersion}/${jarName}"
+                        
+                        println "  Downloading from Maven Central: ${jarName}..."
+                        def downloadCmd = System.getProperty('os.name').toLowerCase().contains('windows')
+                            ? ['powershell', '-Command', "Invoke-WebRequest -Uri '${url}' -OutFile '${destFile}'"]
+                            : ['curl', '-f', '-L', '-o', destFile.absolutePath, url]
+                        
+                        def proc = downloadCmd.execute()
+                        proc.waitFor()
+                        
+                        if (proc.exitValue() == 0 && destFile.exists()) {
+                            println "  Cached: ${jarName}"
+                            jarCount++
+                        } else {
+                            println "  Warning: Failed to download ${jarName}"
+                            destFile.delete()
+                            return
+                        }
+                    }
+                }
+                
+                // Now fetch transitive dependencies from this JAR's POM
+                def pomPath = "META-INF/maven/${group}/${name}/pom.xml"
+                try {
+                    def pomContent = new java.util.zip.ZipFile(destFile).getInputStream(
+                        new java.util.zip.ZipEntry(pomPath)
+                    ).text
+                    def pom = new XmlSlurper().parseText(pomContent)
+                    pom.dependencies.dependency.each { dep ->
+                        def scope = dep.scope.text()
+                        // Only fetch compile/runtime dependencies, skip test/provided
+                        if (!scope || scope == 'compile' || scope == 'runtime') {
+                            def transGroupId = dep.groupId.text()
+                            def transArtifactId = dep.artifactId.text()
+                            def transVersion = dep.version.text()
+                            if (transGroupId && transArtifactId && transVersion) {
+                                fetchDependency("${transGroupId}:${transArtifactId}:${transVersion}", processed, m2Repo)
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // POM not found or parse error - skip transitives
+                }
+            } catch (Exception e) {
+                println "  Warning: Could not fetch ${depCoord}: ${e.message}"
+            }
+        }
+        
+        // Fetch external dependencies from local Maven cache or Maven Central
+        if (!dependencies.isEmpty()) {
+            println "Fetching ${dependencies.size()} external dependencies..."
+            
+            def m2Repo = new File(System.getProperty('user.home'), '.m2/repository')
+            def processed = [] as Set
+            
+            dependencies.each { depCoord ->
+                fetchDependency(depCoord, processed, m2Repo)
+            }
+        }
+
+        println "Successfully cached ${jarCount} JARs for Yoko ${version}"
+        println "Cache location: ${cacheDir}"
+    }
+}
+
+// Task to fetch and cache a specific Yoko version from GitHub releases
+task fetchYokoVersion {
+    description = 'Fetch and cache a specific Yoko version from GitHub releases using gh CLI'
+    group = 'interop'
+
+    doLast {
+        def version = project.findProperty('yokoVersion')
+        if (!version) {
+            throw new GradleException("Please specify -PyokoVersion=<version> (e.g., -PyokoVersion=1.5.3)")
+        }
+
+        def cacheDir = file("${System.getProperty('user.home')}/.yoko-interop-cache/${version}")
+
+        // Check if already cached
+        if (cacheDir.exists() && cacheDir.list().length > 0) {
+            println "Version ${version} is already cached in ${cacheDir}"
+            return
+        }
+
+        println "Fetching Yoko version ${version} from GitHub releases..."
+
+        // Check if gh CLI is available
+        try {
+            exec {
+                commandLine 'gh', '--version'
+                standardOutput = new ByteArrayOutputStream()
+                errorOutput = new ByteArrayOutputStream()
+            }
+        } catch (Exception e) {
+            throw new GradleException("GitHub CLI (gh) is not installed. Install it from https://cli.github.com/")
+        }
+
+        // Create cache directory
+        cacheDir.mkdirs()
+
+        // Create a temporary directory for downloads
+        def tempDir = file("${buildDir}/tmp/yoko-fetch-${version}")
+        tempDir.mkdirs()
+
+        try {
+            // Download release assets
+            println "Downloading release assets for v${version}..."
+            exec {
+                workingDir tempDir
+                commandLine 'gh', 'release', 'download', "v${version}",
+                    '--repo', 'OpenLiberty/yoko',
+                    '--pattern', '*.jar',
+                    '--skip-existing'
+            }
+
+            // Copy downloaded JARs to cache
+            def jarCount = 0
+            fileTree(tempDir) {
+                include '*.jar'
+                exclude '*-javadoc.jar'
+                exclude '*-sources.jar'
+            }.each { jarFile ->
+                copy {
+                    from jarFile
+                    into cacheDir
+                }
+                println "  Cached: ${jarFile.name}"
+                jarCount++
+            }
+
+            if (jarCount == 0) {
+                throw new GradleException("No JARs found in release v${version}. The release may not contain JAR artifacts.")
+            }
+
+            // Parse POMs and fetch transitive dependencies
+            println "Fetching transitive dependencies..."
+            def dependencies = [] as Set
+            fileTree(cacheDir) {
+                include '*.jar'
+            }.each { jarFile ->
+                def pomPath = "META-INF/maven/io.openliberty.yoko/${jarFile.name.replaceAll(/-\d+.*\.jar$/, '')}/pom.xml"
+                try {
+                    def pomContent = new java.util.zip.ZipFile(jarFile).getInputStream(
+                        new java.util.zip.ZipEntry(pomPath)
+                    ).text
+                    def pom = new XmlSlurper().parseText(pomContent)
+                    pom.dependencies.dependency.each { dep ->
+                        def groupId = dep.groupId.text()
+                        def artifactId = dep.artifactId.text()
+                        def depVersion = dep.version.text()
+                        // Only fetch external dependencies (not Yoko modules)
+                        if (!groupId.startsWith('io.openliberty.yoko')) {
+                            dependencies.add("${groupId}:${artifactId}:${depVersion}")
+                        }
+                    }
+                } catch (Exception e) {
+                    // POM not found or parse error - skip
+                }
+            }
+
+            // Helper function to fetch a dependency and its transitives recursively
+            def fetchDependency
+            fetchDependency = { String depCoord, Set<String> processed, File m2Repo ->
+                if (processed.contains(depCoord)) return
+                processed.add(depCoord)
+                
+                try {
+                    def parts = depCoord.split(':')
+                    def group = parts[0]
+                    def name = parts[1]
+                    def depVersion = parts[2]
+                    
+                    def jarName = "${name}-${depVersion}.jar"
+                    def destFile = new File(cacheDir, jarName)
+                    
+                    if (destFile.exists()) {
+                        println "  Already cached: ${jarName}"
+                        jarCount++
+                    } else {
+                        // Check local Maven cache first
+                        def localPath = new File(m2Repo, "${group.replace('.', '/')}/${name}/${depVersion}/${jarName}")
+                        if (localPath.exists()) {
+                            println "  Copying from local Maven cache: ${jarName}"
+                            copy {
+                                from localPath
+                                into cacheDir
+                            }
+                            jarCount++
+                        } else {
+                            // Download from Maven Central
+                            def groupPath = group.replace('.', '/')
+                            def url = "https://repo1.maven.org/maven2/${groupPath}/${name}/${depVersion}/${jarName}"
+                            
+                            println "  Downloading from Maven Central: ${jarName}..."
+                            def downloadCmd = System.getProperty('os.name').toLowerCase().contains('windows')
+                                ? ['powershell', '-Command', "Invoke-WebRequest -Uri '${url}' -OutFile '${destFile}'"]
+                                : ['curl', '-f', '-L', '-o', destFile.absolutePath, url]
+                            
+                            def proc = downloadCmd.execute()
+                            proc.waitFor()
+                            
+                            if (proc.exitValue() == 0 && destFile.exists()) {
+                                println "  Cached: ${jarName}"
+                                jarCount++
+                            } else {
+                                println "  Warning: Failed to download ${jarName}"
+                                destFile.delete()
+                                return
+                            }
+                        }
+                    }
+                    
+                    // Now fetch transitive dependencies from this JAR's POM
+                    def pomPath = "META-INF/maven/${group}/${name}/pom.xml"
+                    try {
+                        def pomContent = new java.util.zip.ZipFile(destFile).getInputStream(
+                            new java.util.zip.ZipEntry(pomPath)
+                        ).text
+                        def pom = new XmlSlurper().parseText(pomContent)
+                        pom.dependencies.dependency.each { dep ->
+                            def scope = dep.scope.text()
+                            // Only fetch compile/runtime dependencies, skip test/provided
+                            if (!scope || scope == 'compile' || scope == 'runtime') {
+                                def transGroupId = dep.groupId.text()
+                                def transArtifactId = dep.artifactId.text()
+                                def transVersion = dep.version.text()
+                                if (transGroupId && transArtifactId && transVersion) {
+                                    fetchDependency("${transGroupId}:${transArtifactId}:${transVersion}", processed, m2Repo)
+                                }
+                            }
+                        }
+                    } catch (Exception e) {
+                        // POM not found or parse error - skip transitives
+                    }
+                } catch (Exception e) {
+                    println "  Warning: Could not fetch ${depCoord}: ${e.message}"
+                }
+            }
+            
+            // Fetch external dependencies from local Maven cache or Maven Central
+            if (!dependencies.isEmpty()) {
+                println "Fetching ${dependencies.size()} external dependencies..."
+                
+                def m2Repo = new File(System.getProperty('user.home'), '.m2/repository')
+                def processed = [] as Set
+                
+                dependencies.each { depCoord ->
+                    fetchDependency(depCoord, processed, m2Repo)
+                }
+            }
+
+            println "Successfully cached ${jarCount} JARs for Yoko ${version}"
+            println "Cache location: ${cacheDir}"
+        } finally {
+            // Clean up temp directory
+            tempDir.deleteDir()
+        }
+    }
+}
+
+// Task to list cached Yoko versions
+task listCachedYokoVersions {
+    description = 'List all cached Yoko versions for interop testing'
+    group = 'interop'
+
+    doLast {
+        def cacheRoot = file("${System.getProperty('user.home')}/.yoko-interop-cache")
+        if (!cacheRoot.exists()) {
+            println "No cached versions found. Cache directory does not exist: ${cacheRoot}"
+            return
+        }
+
+        println "Cached Yoko versions:"
+        cacheRoot.listFiles().each { versionDir ->
+            if (versionDir.isDirectory()) {
+                def jarCount = versionDir.listFiles().findAll { it.name.endsWith('.jar') }.size()
+                println "  ${versionDir.name} (${jarCount} JARs)"
+            }
+        }
+    }
+}
+
+// Task to clean cached Yoko JARs
+task cleanYokoCache {
+    description = 'Remove all cached Yoko version JARs'
+    group = 'interop'
+
+    doLast {
+        def cacheRoot = file("${System.getProperty('user.home')}/.yoko-interop-cache")
+        if (cacheRoot.exists()) {
+            println "Removing cache directory: ${cacheRoot}"
+            cacheRoot.deleteDir()
+            println "Cache cleared successfully"
+        } else {
+            println "Cache directory does not exist: ${cacheRoot}"
+        }
+    }
+}
+
+// Task to clean Yoko worktrees
+task cleanYokoWorktrees {
+    description = 'Remove all Yoko version worktrees'
+    group = 'interop'
+
+    doLast {
+        def worktreeRoot = file("${projectDir}/worktrees")
+
+        if (worktreeRoot.exists()) {
+            println "Removing worktrees..."
+            worktreeRoot.listFiles().each { worktreeDir ->
+                if (worktreeDir.isDirectory()) {
+                    println "  Removing worktree: ${worktreeDir.name}"
+                    try {
+                        exec {
+                            commandLine 'git', 'worktree', 'remove', worktreeDir.absolutePath, '--force'
+                            ignoreExitValue = true
+                        }
+                    } catch (Exception e) {
+                        println "  Warning: Could not remove worktree via git command: ${e.message}"
+                    }
+                }
+            }
+            // Remove the worktrees directory itself
+            worktreeRoot.deleteDir()
+            println "Worktrees cleared successfully"
+        } else {
+            println "Worktrees directory does not exist: ${worktreeRoot}"
+        }
+    }
+}
+
+// Task to clean both cache and worktrees
+task cleanCachedYokoVersions {
+    description = 'Remove all cached Yoko versions (JARs and worktrees)'
+    group = 'interop'
+    dependsOn cleanYokoCache, cleanYokoWorktrees
+}

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,9 @@ def validateGradleVersions() {
 // Run validation during configuration phase
 validateGradleVersions()
 
+// Apply interop testing tasks
+apply from: 'build-interop.gradle'
+
 // Apply release configuration
 apply from: 'build-release.gradle'
 
@@ -187,7 +190,15 @@ subprojects { sp ->
     jvmArgs '--add-opens=java.base/java.io=ALL-UNNAMED'
     jvmArgs '--add-opens=java.base/java.util=ALL-UNNAMED'
     jvmArgs '--add-opens=java.rmi/java.rmi=ALL-UNNAMED'
-    useJUnitPlatform()
+    useJUnitPlatform {
+      // Support excluding tags via system property (e.g., -Dtest.excludeTags=interop)
+      def tagsToExclude = System.getProperty('test.excludeTags')
+      if (tagsToExclude) {
+        tagsToExclude.split(',').each { tag ->
+          excludeTags tag.trim()
+        }
+      }
+    }
     workingDir = "$buildDir/testWorkingDir"
     doFirst {workingDir.mkdirs()}
 

--- a/docs/pages/interop-testing.md
+++ b/docs/pages/interop-testing.md
@@ -1,0 +1,88 @@
+# Yoko Interoperability Testing
+
+## Overview
+
+Yoko includes infrastructure for testing interoperability between different versions of Yoko. This allows you to verify that the current development version can communicate correctly with earlier released versions.
+
+## Quick Start
+
+### 1. Build or Fetch a Yoko Version
+
+Before running interop tests, you need to cache the Yoko version you want to test against. You have two options:
+
+**Option A: Fetch from GitHub releases (faster)**
+```bash
+./gradlew fetchYokoVersion -PyokoVersion=1.5.3
+```
+
+This downloads the release JARs from GitHub using the `gh` CLI and caches them in `~/.yoko-interop-cache/<version>/`.
+
+**Option B: Build from source**
+```bash
+./gradlew buildYokoVersion -PyokoVersion=1.5.3
+```
+
+This creates a git worktree, builds the specified version from source, and caches all JARs in `~/.yoko-interop-cache/<version>/`.
+
+If this step is omitted, any tests relying on this version will be skipped.
+
+### 2. Write an Interop Test
+
+Use `@InteropTest` to mark tests that require a specific Yoko version:
+
+```java
+@InteropTest(V1_5_3)
+public class MyInteropTest {
+    public interface MyService extends Remote {
+        Object echo(Object o);
+    }
+
+    @RemoteImpl
+    static MyService serviceImpl = o -> o;
+
+    @Test
+    void testCompatibility(MyService stub) {
+        // Test logic here
+    }
+}
+```
+
+The `@InteropTest` annotation automatically:
+- Tags the test with `@Tag("interop")` for selective execution
+- Configures `@ConfigureServer(separation = INTER_PROCESS)`
+- Sets up the server to run with the specified Yoko version
+
+## Gradle Tasks
+
+```bash
+# Fetch and cache a version from GitHub releases (requires gh CLI)
+./gradlew fetchYokoVersion -PyokoVersion=1.5.3
+
+# Build and cache a version from source
+./gradlew buildYokoVersion -PyokoVersion=1.5.3
+
+# List cached versions
+./gradlew listCachedYokoVersions
+
+# Clean cached JARs only
+./gradlew cleanYokoCache
+
+# Clean worktrees only
+./gradlew cleanYokoWorktrees
+
+# Clean both JARs and worktrees
+./gradlew cleanCachedYokoVersions
+```
+
+
+## Cache Locations
+
+- **JARs**: `~/.yoko-interop-cache/<version>/`
+- **Worktrees**: `<project-root>/worktrees/<version>/`
+
+## Key Constraints
+
+- `@InteropTest` automatically configures `separation = INTER_PROCESS`
+- Tests are tagged with `@Tag("interop")` and can be excluded in CI builds
+- Tests automatically skip if the version isn't cached (using JUnit assumptions)
+- Server runs with the specified version; client always uses current development version

--- a/testify-iiop/build.gradle
+++ b/testify-iiop/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 IBM Corporation and others.
+ * Copyright 2026 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,62 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-dependencies {
-  implementation "org.hamcrest:hamcrest:2.1"
-  implementation "org.junit.jupiter:junit-jupiter:5.9.0"
-  implementation project(':yoko-spec-corba')
-  implementation project(':yoko-rmi-spec')
-  implementation project(':yoko-util')
-  implementation project(':yoko-rmi-impl')
-  implementation project(':yoko-core')
-  implementation project(":testify")
+// Separate configurations for test framework vs Yoko dependencies
+configurations {
+    testFramework {
+        canBeResolved = true
+        canBeConsumed = false
+        // Extend from testLib which already has hamcrest and junit-jupiter
+        extendsFrom testLib
+    }
+    yokoDeps {
+        canBeResolved = false
+        canBeConsumed = false
+    }
+    // Make implementation extend from both
+    implementation.extendsFrom testFramework, yokoDeps
 }
+
+dependencies {
+  // Test framework dependencies (testLib already provides hamcrest and junit-jupiter)
+  testFramework project(":testify")
+  
+  // Yoko dependencies
+  yokoDeps project(':yoko-spec-corba')
+  yokoDeps project(':yoko-rmi-spec')
+  yokoDeps project(':yoko-util')
+  yokoDeps project(':yoko-rmi-impl')
+  yokoDeps project(':yoko-core')
+}
+
+// Task to generate test framework dependencies file for interop testing
+task generateTestDependencies {
+    description = 'Generate a file listing test framework dependencies (excluding Yoko projects and their dependencies)'
+    group = 'build'
+    
+    def outputFile = file("${buildDir}/test-dependencies.txt")
+    def resourceFile = file("${buildDir}/resources/main/testify/iiop/test-dependencies.txt")
+    outputs.files(outputFile, resourceFile)
+    
+    doLast {
+        // Use testFramework configuration which excludes Yoko and its dependencies
+        def testDeps = configurations.testFramework.resolvedConfiguration.resolvedArtifacts
+            .collect { it.file.absolutePath }
+            .sort()
+        
+        // Write to build directory
+        outputFile.parentFile.mkdirs()
+        outputFile.text = testDeps.join('\n')
+        
+        // Also write to resources so it's available at runtime
+        resourceFile.parentFile.mkdirs()
+        resourceFile.text = testDeps.join('\n')
+        
+        println "Generated test dependencies file: ${outputFile}"
+        println "Generated test dependencies resource: ${resourceFile}"
+        println "Test framework dependencies count: ${testDeps.size()}"
+    }
+}
+
+// Ensure test dependencies are generated before compiling
+processResources.dependsOn generateTestDependencies

--- a/testify-iiop/src/main/java/testify/iiop/annotation/InteropTest.java
+++ b/testify-iiop/src/main/java/testify/iiop/annotation/InteropTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package testify.iiop.annotation;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static testify.iiop.annotation.ConfigureServer.Separation.INTER_PROCESS;
+
+/**
+ * Marks a test as an interop test that requires a specific Yoko version.
+ * Automatically configures the server to run in a separate process with the specified Yoko version.
+ *
+ * Tests marked with this annotation may be skipped if the required Yoko version is not cached.
+ * To cache a version, run: ./gradlew buildYokoVersion -PyokoVersion=X.Y.Z
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("interop")
+@ConfigureServer(separation = INTER_PROCESS)
+public @interface InteropTest {
+    /**
+     * The Yoko version to use for the server process.
+     */
+    YokoVersion value();
+
+    enum YokoVersion {
+        V1_5_0, V1_5_1, V1_5_2, V1_5_3, V1_6_0, V1_6_1;
+        public final String version = name().substring(1).replace('_', '.');
+    }
+}

--- a/testify-iiop/src/main/java/testify/iiop/annotation/ServerSteward.java
+++ b/testify-iiop/src/main/java/testify/iiop/annotation/ServerSteward.java
@@ -28,10 +28,18 @@ import testify.bus.Bus;
 import testify.parts.PartRunner;
 
 import javax.rmi.PortableRemoteObject;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.rmi.Remote;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,14 +48,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
 import static javax.rmi.PortableRemoteObject.narrow;
 import static org.hamcrest.CoreMatchers.anyOf;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 import static testify.annotation.runner.PartRunners.requirePartRunner;
 import static testify.bus.key.MemberKey.getMemberEvaluationType;
@@ -72,13 +84,23 @@ class ServerSteward {
     private final List<Method> beforeMethods;
     private final List<Method> afterMethods;
     private final ConfigureServer config;
+    private final InteropTest.YokoVersion yokoVersion;
     private final ExtensionContext context;
     private final ServerComms serverComms;
     private final ServerController serverControl;
     private ServerSteward(ConfigureServer config, ExtensionContext context) {
-        this.config = config;
         this.context = context;
         Class<?> testClass = context.getRequiredTestClass();
+
+        // Check for @InteropTest annotation to get Yoko version
+        this.yokoVersion = findAnnotation(testClass, InteropTest.class).map(InteropTest::value).orElse(null);
+
+        // If @InteropTest is present, validate that separation is INTER_PROCESS
+        if (null != yokoVersion && config.separation() != INTER_PROCESS) {
+            throw new Error("@InteropTest requires @ConfigureServer(separation = INTER_PROCESS)");
+        }
+
+        this.config = config;
         this.controlFields = AnnotationButler.forClass(ConfigureServer.Control.class)
                 .requireTestAnnotation(ConfigureServer.class)
                 .assertPublic()
@@ -186,8 +208,7 @@ class ServerSteward {
 
         // blow up if jvm args specified unnecessarily
         if (config.separation() != INTER_PROCESS && config.jvmArgs().length > 0)
-            throw new Error("The annotation @" + ConfigureServer.class.getSimpleName()
-                    + " must not include JVM arguments unless it is configured as " + INTER_PROCESS);
+            throw new Error("@ConfigureServer must not include JVM arguments unless separation = INTER_PROCESS");
 
         boolean colloc = isCollocated();
         ConfigureOrb cfg = colloc ? combineClientAndServerOrbConfig() : config.serverOrb();
@@ -204,17 +225,76 @@ class ServerSteward {
     }
 
     void beforeAll(ExtensionContext ctx) {
-        // Configure the PartRunner now that all extensions have had a chance to configure it
+        // Check if a specific Yoko version is required and if it's available
+        if (null != yokoVersion) {
+            Path cacheDir = Paths.get(System.getProperty("user.home"), ".yoko-interop-cache", yokoVersion.version);
+            assumeTrue(assertDoesNotThrow(() -> Files.isDirectory(cacheDir) && Files.list(cacheDir).findAny().isPresent()),
+                "Yoko version " + yokoVersion.version + " is not cached. Run: ./gradlew buildYokoVersion -PyokoVersion=" + yokoVersion.version);
+        }
+
+        // Configure the PartRunner
         PartRunner runner = requirePartRunner(ctx);
-        // does this part run in a thread or a new process?
-        if (this.config.separation() == INTER_PROCESS) runner.useNewJVMWhenForking(this.config.jvmArgs());
-        else runner.useNewThreadWhenForking();
+        if (config.separation() == INTER_PROCESS) {
+            runner.useNewJVMWhenForking(buildJvmArgs());
+        } else {
+            runner.useNewThreadWhenForking();
+        }
 
         // Launch the server now that the PartRunner is configured
         serverComms.launch(runner);
 
         populateControlFields(ctx);
         serverControl.start();
+    }
+
+    private String[] buildJvmArgs() {
+        List<String> args = new ArrayList<>(Arrays.asList(config.jvmArgs()));
+
+        // If a specific Yoko version is requested, prepend cached JARs to classpath
+        if (null != yokoVersion) {
+            // Build classpath: old Yoko JARs + old dependencies + test classes only
+            String versionClasspath = buildClasspathForVersion(yokoVersion.version);
+            Set<String> allowedPaths = loadTestDependencies();
+
+            // Filter current classpath to only include test dependencies and build classes
+            String filteredClasspath = Arrays.stream(System.getProperty("java.class.path").split(File.pathSeparator))
+                .filter(path -> allowedPaths.contains(path) || path.contains("/build/classes/"))
+                .collect(joining(File.pathSeparator));
+
+            // Add classpath and module access to JVM args
+            args.add("-cp");
+            args.add(versionClasspath + File.pathSeparator + filteredClasspath);
+            args.add("--add-opens");
+            args.add("java.base/java.lang=ALL-UNNAMED");
+        }
+
+        return args.toArray(new String[0]);
+    }
+
+    private String buildClasspathForVersion(String version) {
+        Path cacheDir = Paths.get(System.getProperty("user.home"), ".yoko-interop-cache", version);
+        if (!Files.exists(cacheDir)) {
+            throw new RuntimeException("Cache directory does not exist for version " + version + ": " + cacheDir);
+        }
+
+        try (var cachedFiles = Files.list(cacheDir)) {
+            // Only include yoko-* JARs, exclude testify (we want old Yoko, current testify)
+            return cachedFiles
+                .map(Path::toString)
+                .filter(p -> p.endsWith(".jar") && p.contains("/yoko-") && !p.contains("testify"))
+                .collect(joining(File.pathSeparator));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to build classpath for version " + version, e);
+        }
+    }
+
+    private Set<String> loadTestDependencies() {
+        try (InputStream is = getClass().getResourceAsStream("/testify/iiop/test-dependencies.txt")) {
+            if (null == is) throw new RuntimeException("Test dependencies file not found. Run './gradlew :testify-iiop:generateTestDependencies'");
+            return new BufferedReader(new InputStreamReader(is)).lines().collect(toSet());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load test dependencies", e);
+        }
     }
 
     void afterAll(ExtensionContext ctx) {

--- a/testify-iiop/src/test/java/testify/iiop/annotation/InteropVersionTest.java
+++ b/testify-iiop/src/test/java/testify/iiop/annotation/InteropVersionTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package testify.iiop.annotation;
+
+import org.junit.jupiter.api.Test;
+import testify.iiop.annotation.ConfigureServer.RemoteImpl;
+
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static testify.iiop.annotation.InteropTest.YokoVersion.V1_5_3;
+
+/**
+ * Basic test to verify interop testing infrastructure works.
+ * Server runs with Yoko 1.5.3, client with current version.
+ *
+ * This test may be skipped if Yoko 1.5.3 is not cached.
+ */
+@InteropTest(V1_5_3)
+public class InteropVersionTest {
+
+    public interface TestService extends Remote {
+        void setValue(int value) throws RemoteException;
+        int getValue() throws RemoteException;
+    }
+
+    static class TestServiceImpl implements TestService {
+        private int value;
+        public void setValue(int value) { this.value = value; }
+        public int getValue() { return value; }
+    }
+
+    @RemoteImpl
+    public static final TestService service = new TestServiceImpl();
+
+    @Test
+    void testBasicInterop(TestService remote) throws Exception {
+        // Test basic RMI-IIOP call across versions
+        remote.setValue(42);
+        assertEquals(42, remote.getValue());
+    }
+}


### PR DESCRIPTION
- Add Gradle tasks for building/fetching/caching different Yoko versions
- Support testing current dev version against released versions
- Add @ConfigureServer yokoVersion parameter for INTER_PROCESS tests
- Implement classpath isolation for version-specific server processes
- Add comprehensive documentation in docs/pages/interop-testing.md
- Include example interop test with Yoko 1.5.3
- Update .gitignore to exclude worktrees directory

Co-authored-by-AI: IBM Bob 1.0.2 (Claude 3.7 Sonnet)
