### PR TITLE
chore: add .bobignore to unignore .bob directory

### DIFF
--- a/.bobignore
+++ b/.bobignore
@@ -1,0 +1,19 @@
+# Copyright 2026 IBM Corporation and others.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Bob Shell Ignore Patterns
+# Unignore the .bob directory (override .gitignore)
+!.bob/


### PR DESCRIPTION
- Add .bobignore configuration file
- Unignore .bob directory to allow Bob Shell to access team configuration
- Lines added: 3, lines removed: 0

Co-authored-by-AI: IBM Bob 1.0.4
