### PR TITLE
refactor(yoko-rmi-impl): add MethodHandleHelper for secure private method access

### DIFF
--- a/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/MethodHandleHelper.java
+++ b/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/MethodHandleHelper.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.yoko.rmi.impl;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
+import java.security.PrivilegedActionException;
+import java.util.function.Function;
+
+import static java.lang.invoke.MethodHandles.publicLookup;
+import static java.lang.invoke.MethodType.methodType;
+import static java.security.AccessController.doPrivileged;
+import static org.apache.yoko.util.PrivilegedActions.exAction;
+
+/**
+ * Helper class for obtaining MethodHandles to methods, including private ones.
+ * This class provides secure access to private methods using MethodHandles,
+ * with support for both Java 8 and Java 9+ APIs.
+ *
+ * <p>Security: This class uses privileged blocks when necessary and does not
+ * expose Lookup objects to prevent security vulnerabilities.</p>
+ */
+enum MethodHandleHelper {
+    ; // Empty enum - prevents instantiation
+
+    /**
+     * Function that creates a Lookup for a given class.
+     * Determined once at class initialization based on Java version.
+     */
+    private static final Function<Class<?>, Lookup> LOOKUP_FACTORY;
+
+    static {
+        Function<Class<?>,Lookup> lookupFactory;
+        try {
+            lookupFactory = createJava9LookupFactory();
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            lookupFactory = createJava8LookupFactory();
+        }
+        LOOKUP_FACTORY = lookupFactory;
+    }
+
+    /**
+     * Creates a lookup factory using Java 9+ privateLookupIn API.
+     */
+    private static Function<Class<?>, Lookup> createJava9LookupFactory()
+            throws NoSuchMethodException, IllegalAccessException {
+        MethodHandle privateLookupIn = publicLookup().findStatic(
+            MethodHandles.class,
+            "privateLookupIn",
+            methodType(
+                Lookup.class,
+                Class.class,
+                Lookup.class
+            )
+        );
+
+        // Capture the lookup once at build time
+        Lookup callerLookup = MethodHandles.lookup();
+
+        return targetClass -> {
+            try {
+                return (Lookup) privateLookupIn.invoke(targetClass, callerLookup);
+            } catch (Throwable t) {
+                throw new RuntimeException("Failed to create private lookup for " + targetClass, t);
+            }
+        };
+    }
+
+    /**
+     * Creates a lookup factory using Java 8 reflection-based approach.
+     */
+    private static Function<Class<?>, Lookup> createJava8LookupFactory() {
+        Constructor<Lookup> constructor;
+        try {
+            constructor = doPrivileged(exAction(() -> {
+                Constructor<Lookup> ctor = Lookup.class.getDeclaredConstructor(Class.class, int.class);
+                ctor.setAccessible(true);
+                return ctor;
+            }));
+        } catch (PrivilegedActionException pae) {
+            throw new ExceptionInInitializerError(pae.getException());
+        }
+
+        return targetClass -> {
+            try {
+                return doPrivileged(exAction(() ->
+                    constructor.newInstance(targetClass, -1) // -1 = all access modes
+                ));
+            } catch (PrivilegedActionException pae) {
+                throw new RuntimeException("Failed to create private lookup for " + targetClass, pae.getException());
+            }
+        };
+    }
+
+    /**
+     * Cache of Lookup objects per class, providing private access to each class.
+     */
+    private static final class LookupCache extends ClassValue<Lookup> {
+        @Override
+        protected Lookup computeValue(Class<?> targetClass) {
+            return LOOKUP_FACTORY.apply(targetClass);
+        }
+    }
+
+    private static final LookupCache PRIVATE_LOOKUPS = new LookupCache();
+
+    /**
+     * Gets a Lookup with private access to the target class.
+     *
+     * @param targetClass the class to get private access to
+     * @return a Lookup with full private access to the target class
+     */
+    private static Lookup getPrivateLookup(Class<?> targetClass) {
+        return PRIVATE_LOOKUPS.get(targetClass);
+    }
+
+    /**
+     * Looks up a private method with the given name and signature.
+     *
+     * @param targetClass the class to look up the method in
+     * @param methodName the name of the method
+     * @param methodType the method signature
+     * @return a MethodHandle for the method, or null if not found
+     * @throws Exception if an error occurs during lookup (other than method not found)
+     */
+    static MethodHandle getMethodHandle(Class<?> targetClass, String methodName, MethodType methodType) throws Exception {
+        Lookup lookup = getPrivateLookup(targetClass);
+        try {
+            return lookup.findVirtual(targetClass, methodName, methodType);
+        } catch (NoSuchMethodException e) {
+            return null; // Method doesn't exist
+        }
+    }
+}

--- a/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/MethodHandleHelper.java
+++ b/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/MethodHandleHelper.java
@@ -149,4 +149,40 @@ enum MethodHandleHelper {
             return null; // Method doesn't exist
         }
     }
+
+    /**
+     * Gets a MethodHandle for reading an instance field.
+     *
+     * @param targetClass the class containing the field
+     * @param fieldName the name of the field
+     * @param fieldType the type of the field
+     * @return a MethodHandle for getting the field value, or null if not found
+     * @throws Exception if an error occurs during lookup (other than field not found)
+     */
+    static MethodHandle getFieldGetter(Class<?> targetClass, String fieldName, Class<?> fieldType) throws Exception {
+        Lookup lookup = getPrivateLookup(targetClass);
+        try {
+            return lookup.findGetter(targetClass, fieldName, fieldType);
+        } catch (NoSuchFieldException e) {
+            return null; // Field doesn't exist
+        }
+    }
+
+    /**
+     * Gets a MethodHandle for writing an instance field.
+     *
+     * @param targetClass the class containing the field
+     * @param fieldName the name of the field
+     * @param fieldType the type of the field
+     * @return a MethodHandle for setting the field value, or null if not found
+     * @throws Exception if an error occurs during lookup (other than field not found)
+     */
+    static MethodHandle getFieldSetter(Class<?> targetClass, String fieldName, Class<?> fieldType) throws Exception {
+        Lookup lookup = getPrivateLookup(targetClass);
+        try {
+            return lookup.findSetter(targetClass, fieldName, fieldType);
+        } catch (NoSuchFieldException e) {
+            return null; // Field doesn't exist
+        }
+    }
 }

--- a/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/TypeRepository.java
+++ b/yoko-rmi-impl/src/main/java/org/apache/yoko/rmi/impl/TypeRepository.java
@@ -27,6 +27,7 @@ import org.apache.yoko.util.yasf.Yasf;
 import org.omg.CORBA.MARSHAL;
 import org.omg.CORBA.ValueDefPackage.FullValueDescription;
 import org.omg.CORBA.portable.IDLEntity;
+import org.omg.CORBA.portable.InputStream;
 import org.omg.SendingContext.CodeBase;
 import org.omg.SendingContext.CodeBaseHelper;
 import org.omg.SendingContext.RunTime;
@@ -54,6 +55,15 @@ import java.util.logging.Logger;
 
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
+import static org.omg.CORBA.TCKind.tk_boolean;
+import static org.omg.CORBA.TCKind.tk_double;
+import static org.omg.CORBA.TCKind.tk_float;
+import static org.omg.CORBA.TCKind.tk_long;
+import static org.omg.CORBA.TCKind.tk_longlong;
+import static org.omg.CORBA.TCKind.tk_octet;
+import static org.omg.CORBA.TCKind.tk_short;
+import static org.omg.CORBA.TCKind.tk_void;
+import static org.omg.CORBA.TCKind.tk_wchar;
 
 public class TypeRepository {
     static final Logger logger = Logger.getLogger(TypeRepository.class.getName());
@@ -101,15 +111,15 @@ public class TypeRepository {
             private Map<Class<?>, Supplier<TypeDescriptor>> genSimpleFactories() {
                 Map<Class<?>, Supplier<TypeDescriptor>> map = new HashMap<>();
                 // Primitive types
-                map.put(boolean.class, () -> new PrimitiveDescriptor(boolean.class, repo, "boolean", org.omg.CORBA.TCKind.tk_boolean, org.omg.CORBA.portable.InputStream::read_boolean, (out, val) -> out.write_boolean((Boolean)val)));
-                map.put(byte.class, () -> new PrimitiveDescriptor(byte.class, repo, "octet", org.omg.CORBA.TCKind.tk_octet, org.omg.CORBA.portable.InputStream::read_octet, (out, val) -> out.write_octet((Byte)val)));
-                map.put(short.class, () -> new PrimitiveDescriptor(short.class, repo, "short", org.omg.CORBA.TCKind.tk_short, org.omg.CORBA.portable.InputStream::read_short, (out, val) -> out.write_short((Short)val)));
-                map.put(char.class, () -> new PrimitiveDescriptor(char.class, repo, "wchar", org.omg.CORBA.TCKind.tk_wchar, org.omg.CORBA.portable.InputStream::read_wchar, (out, val) -> out.write_wchar((Character)val)));
-                map.put(int.class, () -> new PrimitiveDescriptor(int.class, repo, "long", org.omg.CORBA.TCKind.tk_long, org.omg.CORBA.portable.InputStream::read_long, (out, val) -> out.write_long((Integer)val)));
-                map.put(long.class, () -> new PrimitiveDescriptor(long.class, repo, "long_long", org.omg.CORBA.TCKind.tk_longlong, org.omg.CORBA.portable.InputStream::read_longlong, (out, val) -> out.write_longlong((Long)val)));
-                map.put(float.class, () -> new PrimitiveDescriptor(float.class, repo, "float", org.omg.CORBA.TCKind.tk_float, org.omg.CORBA.portable.InputStream::read_float, (out, val) -> out.write_float((Float)val)));
-                map.put(double.class, () -> new PrimitiveDescriptor(double.class, repo, "double", org.omg.CORBA.TCKind.tk_double, org.omg.CORBA.portable.InputStream::read_double, (out, val) -> out.write_double((Double)val)));
-                map.put(void.class, () -> new PrimitiveDescriptor(void.class, repo, "void", org.omg.CORBA.TCKind.tk_void, in -> null, (out, val) -> {}));
+                map.put(boolean.class, () -> new PrimitiveDescriptor(boolean.class, repo, "boolean", tk_boolean, InputStream::read_boolean, (out, val) -> out.write_boolean((Boolean)val)));
+                map.put(byte.class, () -> new PrimitiveDescriptor(byte.class, repo, "octet", tk_octet, InputStream::read_octet, (out, val) -> out.write_octet((Byte)val)));
+                map.put(short.class, () -> new PrimitiveDescriptor(short.class, repo, "short", tk_short, InputStream::read_short, (out, val) -> out.write_short((Short)val)));
+                map.put(char.class, () -> new PrimitiveDescriptor(char.class, repo, "wchar", tk_wchar, InputStream::read_wchar, (out, val) -> out.write_wchar((Character)val)));
+                map.put(int.class, () -> new PrimitiveDescriptor(int.class, repo, "long", tk_long, InputStream::read_long, (out, val) -> out.write_long((Integer)val)));
+                map.put(long.class, () -> new PrimitiveDescriptor(long.class, repo, "long_long", tk_longlong, InputStream::read_longlong, (out, val) -> out.write_longlong((Long)val)));
+                map.put(float.class, () -> new PrimitiveDescriptor(float.class, repo, "float", tk_float, InputStream::read_float, (out, val) -> out.write_float((Float)val)));
+                map.put(double.class, () -> new PrimitiveDescriptor(double.class, repo, "double", tk_double, InputStream::read_double, (out, val) -> out.write_double((Double)val)));
+                map.put(void.class, () -> new PrimitiveDescriptor(void.class, repo, "void", tk_void, in -> null, (out, val) -> {}));
                 // Other simple types
                 map.put(String.class, () -> new StringDescriptor(repo));
                 map.put(Class.class, () -> new ClassDescriptor(repo));


### PR DESCRIPTION
- Add MethodHandleHelper utility class for obtaining MethodHandles to private methods
- Implement Java 8 and Java 9+ compatible lookup strategies with automatic version detection
- Use ClassValue-based caching for Lookup objects to improve performance
- Refactor TypeRepository to use static imports for CORBA TCKind constants and InputStream
- Simplify primitive type descriptor initialization with cleaner import structure
- Lines added: 171, lines removed: 9

Co-authored-by-AI: IBM Bob 1.0.4
