### PR TITLE
style(poa): improve unsupported policy logging with POA name and reduced severity

### DIFF
--- a/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/POAPolicies.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/POAPolicies.java
@@ -79,6 +79,10 @@ final public class POAPolicies {
     private final short bidirPolicyValue;
 
     POAPolicies(ORBInstance orbInstance, Policy[] policies) {
+        this(orbInstance, policies, null);
+    }
+
+    POAPolicies(ORBInstance orbInstance, Policy[] policies, String poaName) {
         // Set the default policy values.
         // These are temporary variables to allow the final fields to be set after the for loop.
         // TODO: refactor to use a builder pattern for conciseness
@@ -113,8 +117,9 @@ final public class POAPolicies {
                     case INTERCEPTOR_CALL_POLICY_ID.value: interceptorCall = InterceptorCallPolicyHelper.narrow(InterceptorCallPolicyHelper.narrow(policy)).value(); break;
                     case ZERO_PORT_POLICY_ID.value: zeroPort = ZeroPortPolicyHelper.narrow(ZeroPortPolicyHelper.narrow(policy)).value(); break;
                     default:
-                        // Unknown policy
-                        POA_INIT_LOG.warning(() -> String.format("Ignoring unsupported policy of type 0x%x", policy.policy_type()));
+                        // Unknown policy - log at fine level since this is expected when new policies are introduced
+                        final String poa = poaName != null ? "POA '" + poaName + "' is ignoring" : "Ignoring";
+                        POA_INIT_LOG.fine(() -> String.format("%s unsupported policy of type 0x%x", poa, policy.policy_type()));
                 }
             }
         }

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/POA_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/POA_impl.java
@@ -413,7 +413,7 @@ final public class POA_impl extends LocalObject implements POA {
         logger.fine(() -> "POA " + name_ + " creating new POA with name " + adapter);
 
         // Are the requested policies valid?
-        POAPolicies policies = new POAPolicies(orbInstance_, rawPolicies);
+        POAPolicies policies = new POAPolicies(orbInstance_, rawPolicies, adapter);
         IntHolder idx = new IntHolder();
         if (!validatePolicies(policies, rawPolicies, idx))
             throw new InvalidPolicy((short) idx.value);


### PR DESCRIPTION
- Add POAPolicies constructor overload accepting optional POA name parameter
- Include POA name in unsupported policy log message for better diagnostics
- Downgrade log level from warning to fine since unknown policies are expected when new Jakarta EE versions introduce new policy types
- Pass POA name from POA_impl.create_POA() to POAPolicies constructor
- Lines added: 8, lines removed: 3

Co-authored-by: Neil Richards <neil_richards@uk.ibm.com>
Co-authored-by-AI: IBM Bob 1.0.3
