### PR TITLE
refactor(util): make LazyReference implement Supplier<T>

### DIFF
--- a/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyReference.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/concurrent/LazyReference.java
@@ -42,7 +42,7 @@ import static java.util.Optional.ofNullable;
  *
  * @param <T> the type of the lazily initialized value
  */
-public class LazyReference<T> {
+public class LazyReference<T> implements Supplier<T> {
     private static final Logger LOGGER = Logger.getLogger(LazyReference.class.getName());
 
     /**


### PR DESCRIPTION
- Added Supplier<T> interface implementation to LazyReference class
- Enables LazyReference to be used directly as a Supplier in functional contexts
- Substantive lines added: 1, lines removed: 1
