### PR TITLE
ci(github): replace self-hosted runners with ubuntu-latest

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 IBM Corporation and others.
+# Copyright 2026 IBM Corporation and others.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ on:
 jobs:
   check-commit-message:
     name: Check Commit Message
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Check Commit Type
         uses: gsactions/commit-message-checker@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   build:
 
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ permissions:
   contents: write
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
- Updated gradle.yml workflow to use ubuntu-latest runner
- Updated publish.yml workflow to use ubuntu-latest runner
- Updated check-commit-message.yml workflow to use ubuntu-latest runner
- Updated copyright year in check-commit-message.yml to 2026
- Lines added: 4, lines removed: 4

Co-authored-by-AI: IBM Bob 1.0.3
