### PR TITLE
refactor/eliminate finalization

### DIFF
--- a/yoko-core/src/main/java/org/apache/yoko/orb/CORBA/Delegate.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/CORBA/Delegate.java
@@ -168,14 +168,7 @@ public final class Delegate extends org.omg.CORBA_2_4.portable.Delegate {
         logged(RETRY_LOG, ex, "Allow retry");
     }
 
-    @SuppressWarnings("deprecation")
-    protected void finalize() throws Throwable {
-        // CollocatedServant must be explicitly destroyed in order to make it eligible for garbage collection
-        if (directServant != null) {
-            directServant.destroy();
-        }
-        super.finalize();
-    }
+
 
     // ------------------------------------------------------------------
     // Standard IDL to Java Mapping

--- a/yoko-core/src/main/java/org/apache/yoko/orb/CORBA/Request.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/CORBA/Request.java
@@ -736,38 +736,6 @@ final public class Request extends org.omg.CORBA.Request {
         raiseDIIExceptions_ = orb._OB_raiseDIIExceptions();
     }
 
-    protected void finalize() throws Throwable {
-        if (state_ == RequestStateSent) {
-            //
-            // TODO: This is a memory leak, as a request has been
-            // sent, but the response has never been picked
-            // up. The correct thing would be to tell the Downcall
-            // object to cancel the request. But we don't have
-            // this ability yet.
-            //
-        }
-
-        //
-        // Find out whether this was a deferred request for which
-        // get_response() hasn't been called yet.
-        //
-        ORBInstance orbInstance = delegate_
-                ._OB_ORBInstance();
-        MultiRequestSender multi = orbInstance
-                .getMultiRequestSender();
-        if (multi != null) // It might be possible that the
-        // MultiRequestSender is already destroyed
-        {
-            //
-            // Remove this request from the list of the outstanding
-            // deferred requests
-            //
-            multi.removeDeferredRequest(this);
-        }
-
-        super.finalize();
-    }
-
     public boolean _OB_completed() {
         synchronized (stateMutex_) {
             return state_ == RequestStateReceived;

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OB/ClientManager.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OB/ClientManager.java
@@ -72,13 +72,6 @@ public final class ClientManager {
     // ClientManager private and protected member implementations
     // ----------------------------------------------------------------------
 
-    protected void finalize() throws Throwable {
-        Assert.ensure(destroyed);
-        Assert.ensure(allClients.isEmpty());
-        Assert.ensure(reusableClients.isEmpty());
-
-        super.finalize();
-    }
 
     // ----------------------------------------------------------------------
     // ClientManager package member implementations

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OB/DowncallStub.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OB/DowncallStub.java
@@ -17,25 +17,11 @@
  */
 package org.apache.yoko.orb.OB;
 
-import static java.util.logging.Level.FINE;
-import static org.apache.yoko.io.AlignmentBoundary.EIGHT_BYTE_BOUNDARY;
-import static org.apache.yoko.util.Arrays.emptyArray;
-import static org.apache.yoko.io.Buffer.createWriteBuffer;
-import static org.apache.yoko.logging.VerboseLogging.RETRY_LOG;
-import static org.apache.yoko.orb.OCI.GiopVersion.GIOP1_2;
-import static org.apache.yoko.orb.exceptions.Transients.NO_USABLE_PROFILE_IN_IOR;
-import static org.apache.yoko.util.Assert.ensure;
-import static org.apache.yoko.util.MinorCodes.MinorShutdownCalled;
-import static org.apache.yoko.util.MinorCodes.describeBadInvOrder;
-import static org.omg.CORBA.CompletionStatus.COMPLETED_NO;
-
-import java.util.Vector;
-import java.util.logging.Logger;
-
 import org.apache.yoko.io.ReadBuffer;
+import org.apache.yoko.io.SimplyCloseable;
 import org.apache.yoko.io.WriteBuffer;
-import org.apache.yoko.orb.CORBA.YokoInputStream;
 import org.apache.yoko.orb.CORBA.OutputStreamHolder;
+import org.apache.yoko.orb.CORBA.YokoInputStream;
 import org.apache.yoko.orb.CORBA.YokoOutputStream;
 import org.apache.yoko.orb.IOP.ServiceContexts;
 import org.apache.yoko.orb.OCI.ConnectorInfo;
@@ -43,6 +29,8 @@ import org.apache.yoko.orb.OCI.ProfileInfo;
 import org.apache.yoko.orb.OCI.ProfileInfoHolder;
 import org.apache.yoko.orb.OCI.TransportInfo;
 import org.apache.yoko.util.Assert;
+import org.apache.yoko.util.concurrent.LazyReference;
+import org.apache.yoko.util.concurrent.YokoCleaner;
 import org.omg.CORBA.BAD_INV_ORDER;
 import org.omg.CORBA.BooleanHolder;
 import org.omg.CORBA.COMM_FAILURE;
@@ -84,11 +72,55 @@ import org.omg.Messaging.PolicyValueSeqHelper;
 import org.omg.Messaging.PolicyValueSeqHolder;
 import org.omg.Messaging.ReplyHandler;
 
+import java.util.Vector;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.FINE;
+import static org.apache.yoko.io.AlignmentBoundary.EIGHT_BYTE_BOUNDARY;
+import static org.apache.yoko.io.Buffer.createWriteBuffer;
+import static org.apache.yoko.logging.VerboseLogging.RETRY_LOG;
+import static org.apache.yoko.orb.OCI.GiopVersion.GIOP1_2;
+import static org.apache.yoko.orb.exceptions.Transients.NO_USABLE_PROFILE_IN_IOR;
+import static org.apache.yoko.util.Arrays.emptyArray;
+import static org.apache.yoko.util.Assert.ensure;
+import static org.apache.yoko.util.MinorCodes.MinorShutdownCalled;
+import static org.apache.yoko.util.MinorCodes.describeBadInvOrder;
+import static org.omg.CORBA.CompletionStatus.COMPLETED_NO;
+
 //
 // DowncallStub is equivalent to the C++ class OB::MarshalStubImpl
 //
 public final class DowncallStub {
     static final Logger logger = Logger.getLogger(DowncallStub.class.getName());
+    private static final YokoCleaner cleaner = YokoCleaner.create();
+
+    //
+    // Shared state for cleanup - must not reference DowncallStub instance
+    // Uses LazyReference to handle lazy initialization of clientProfilePairs_
+    //
+    private static final class CleanupState {
+        final ORBInstance orbInstance;
+        final LazyReference<Vector<ClientProfilePair>> clientProfilePairsRef;
+
+        CleanupState(ORBInstance orbInstance, LazyReference<Vector<ClientProfilePair>> clientProfilePairsRef) {
+            this.orbInstance = orbInstance;
+            this.clientProfilePairsRef = clientProfilePairsRef;
+        }
+
+        void cleanup() {
+            ClientManager clientManager = orbInstance.getClientManager();
+            if (clientManager != null && clientProfilePairsRef != null) {
+                Vector<ClientProfilePair> pairs = clientProfilePairsRef.get();
+                if (pairs != null) {
+                    for (ClientProfilePair pair : pairs) {
+                        clientManager.releaseClient(pair.client);
+                    }
+                    pairs.removeAllElements();
+                }
+            }
+        }
+    }
+
     //
     // The ORBInstance object
     //
@@ -107,17 +139,16 @@ public final class DowncallStub {
     private RefCountPolicyList policies_;
 
     //
-    // All client/profile pairs
+    // All client/profile pairs - uses LazyReference for thread-safe lazy initialization
     //
-    private Vector<ClientProfilePair> clientProfilePairs_;
+    private final LazyReference<Vector<ClientProfilePair>> clientProfilePairsRef;
 
     //
     // We need a class to carry the DowncallStub and Downcall across
     // a portable stub invocation
     //
-    private class InvocationContext {
+    private static class InvocationContext {
         DowncallStub downcallStub;
-
         Downcall downcall;
     }
 
@@ -125,66 +156,42 @@ public final class DowncallStub {
     // Private and protected member implementations
     // ------------------------------------------------------------------
     private synchronized ClientProfilePair getClientProfilePair() throws FailureException {
-        // Lazy initialization of the client/profile pairs
-        if (null == clientProfilePairs_) {
-            // Get all clients that can be used
-            ClientManager clientManager = orbInstance_.getClientManager();
-            clientProfilePairs_ = clientManager.getClientProfilePairs(IOR_, policies_.value);
-        }
+        // Get the lazily-initialized client/profile pairs
+        Vector<ClientProfilePair> pairs = clientProfilePairsRef.get();
 
         // If we can't get any client/profile pairs, set and raise the
         // failure exception, and let the stub handle this.
-        if (clientProfilePairs_.isEmpty()) {
+        if (pairs.isEmpty()) {
             RETRY_LOG.fine(() -> "No profiles available");
             throw new FailureException(NO_USABLE_PROFILE_IN_IOR.create());
         }
-        // NB: see handleFailureException() for how clientProfilePairs_ is modified (pruned) in exception
+        // NB: see handleFailureException() for how clientProfilePairsRef is modified (pruned) in exception
         // processing (so the first element may change)
-        return clientProfilePairs_.elementAt(0);
+        return pairs.elementAt(0);
     }
 
-    private void destroy() {
-        //
-        // If the ORB has been destroyed then the clientManager can be nil
-        //
-        ClientManager clientManager = orbInstance_.getClientManager();
 
-        if (clientManager != null && clientProfilePairs_ != null) {
-            for (ClientProfilePair pair: clientProfilePairs_) {
-                clientManager.releaseClient(pair.client);
-            }
-        }
-
-        clientProfilePairs_.removeAllElements();
-    }
-
-    protected void finalize() throws Throwable {
-        destroy();
-
-        super.finalize();
-    }
 
     // ------------------------------------------------------------------
     // Public member implementations
     // ------------------------------------------------------------------
 
     public DowncallStub(ORBInstance orbInstance, IOR ior, IOR origIOR, RefCountPolicyList policies) {
-        clientProfilePairs_ = null;
-
-        //
-        // Save the ORBInstance object
-        //
+        // Initialize fields
         orbInstance_ = orbInstance;
-        //
-        // Save the IOR
-        //
         IOR_ = ior;
         origIOR_ = origIOR;
-
-        //
-        // Save the policies
-        //
         policies_ = policies;
+
+        // Lazy initialization of client/profile pairs
+        clientProfilePairsRef = new LazyReference<>(() -> {
+            ClientManager clientManager = orbInstance_.getClientManager();
+            return clientManager.getClientProfilePairs(IOR_, policies_.value);
+        });
+
+        // Register cleanup action - uses shared state to avoid referencing 'this'
+        CleanupState state = new CleanupState(orbInstance_, clientProfilePairsRef);
+        @SuppressWarnings("resource") SimplyCloseable ignored = cleaner.register(this, state::cleanup);
     }
 
     //
@@ -339,10 +346,11 @@ public final class DowncallStub {
                     MinorShutdownCalled,
                     COMPLETED_NO);
 
-        clientProfilePairs_.stream()
+        Vector<ClientProfilePair> pairs = clientProfilePairsRef.get();
+        pairs.stream()
                 .filter(cp::equals)
                 .findFirst()
-                .ifPresent(clientProfilePairs_::remove);
+                .ifPresent(pairs::remove);
 
         // We only retry upon COMM_FAILURE, TRANSIENT, and NO_RESPONSE
         try {
@@ -362,7 +370,7 @@ public final class DowncallStub {
         }
 
         // If no client/profile pairs are left, we cannot retry either
-        if (clientProfilePairs_.isEmpty()) {
+        if (pairs.isEmpty()) {
             logger.log(FINE, ex.exception, () -> "no profiles left to try");
             throw ex;
         }

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OB/GIOPServer.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OB/GIOPServer.java
@@ -43,17 +43,6 @@ final class GIOPServer extends Server {
     protected GIOPServerStarter starter_; // The server starter
 
     // ----------------------------------------------------------------------
-    // GIOPServer private and protected member implementations
-    // ----------------------------------------------------------------------
-
-    protected void finalize() throws Throwable {
-        ensure(destroy_);
-        ensure(starter_ == null);
-
-        super.finalize();
-    }
-
-    // ----------------------------------------------------------------------
     // GIOPServer package member implementations
     // ----------------------------------------------------------------------
 

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OB/GIOPServerStarter.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OB/GIOPServerStarter.java
@@ -32,7 +32,7 @@ import static org.apache.yoko.orb.OB.GIOPServerStarter.ServerState.HOLDING;
 
 abstract class GIOPServerStarter {
     static final Logger logger = Logger.getLogger(GIOPServerStarter.class.getName());
-    
+
     protected final ORBInstance orbInstance_; // The ORBInstance
 
     protected final Acceptor acceptor_; // The acceptor
@@ -57,12 +57,6 @@ abstract class GIOPServerStarter {
     // ----------------------------------------------------------------------
     // GIOPServer private and protected member implementation
     // ----------------------------------------------------------------------
-
-    protected void finalize() throws Throwable {
-        Assert.ensure(serverState == CLOSED);
-
-        super.finalize();
-    }
 
     //
     // Emit a trace message when closing the acceptor

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OB/InitialServiceManager.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OB/InitialServiceManager.java
@@ -60,10 +60,6 @@ public final class InitialServiceManager {
     // InitialServiceManager private and protected member implementations
     // ----------------------------------------------------------------------
 
-    protected void finalize() throws Throwable {
-        Assert.ensure(destroy_);
-        super.finalize();
-    }
 
     // ----------------------------------------------------------------------
     // InitialServiceManager package member implementations

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OB/ORBInstance.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OB/ORBInstance.java
@@ -77,10 +77,6 @@ public final class ORBInstance {
     private OrbAsyncHandler asyncHandler;
     private final AtomicBoolean destroyCalled = new AtomicBoolean(); // True if destroy() was called
 
-    protected void finalize() throws Throwable {
-        Assert.ensure(destroyCalled.get());
-        super.finalize();
-    }
 
     public ORBInstance(ORB orb, String orbId, String serverID,
                        String serverInstance, ObjectFactory objectFactory,
@@ -201,7 +197,7 @@ public final class ORBInstance {
         // CoreTraceLevels is not destroyed -- it is indestructible
 
         // Client and server executors shut down in the ORBControl
-        
+
         conFactoryRegistry = null;
         accFactoryRegistry = null;
         unknownExceptionStrategy = null;
@@ -292,11 +288,11 @@ public final class ORBInstance {
     public Phaser getServerPhaser() {
         return serverPhaser;
     }
-    
+
     public ExecutorService getClientExecutor() {
         return clientExecutor;
     }
-    
+
     public Phaser getClientPhaser() {
         return clientPhaser;
     }

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OB/ServerManager.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OB/ServerManager.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
 
 public final class ServerManager {
     static final Logger logger = getLogger(ServerManager.class.getName());
-    
+
     private boolean destroy_; // if destroy() was called
 
     private CollocatedServer collocatedServer_; // The collocated server
@@ -40,13 +40,6 @@ public final class ServerManager {
     // ServerManager private and protected member implementations
     // ----------------------------------------------------------------------
 
-    protected void finalize() throws Throwable {
-        Assert.ensure(destroy_);
-        Assert.ensure(allServers_.isEmpty());
-        Assert.ensure(collocatedServer_ == null);
-
-        super.finalize();
-    }
 
     // ----------------------------------------------------------------------
     // ServerManager public member implementations

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OB/ThreadPool.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OB/ThreadPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 IBM Corporation and others.
+ * Copyright 2026 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,12 +70,6 @@ final class ThreadPool {
         }
     }
 
-    protected void finalize() throws Throwable {
-        if (!destroy_)
-            throw new InternalError();
-
-        super.finalize();
-    }
 
     void destroy() {
         synchronized (this) {

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OB/ValueFactoryManager.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OB/ValueFactoryManager.java
@@ -57,10 +57,6 @@ public final class ValueFactoryManager {
     // ValueFactoryManager private and protected member implementations
     // ----------------------------------------------------------------------
 
-    protected void finalize() throws Throwable {
-        Assert.ensure(destroy_);
-        super.finalize();
-    }
 
     // ----------------------------------------------------------------------
     // ValueFactoryManager package member implementations

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OBCORBA/ORB_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OBCORBA/ORB_impl.java
@@ -493,13 +493,6 @@ public class ORB_impl extends ORBSingleton {
         }
     }
 
-    protected void finalize() throws Throwable {
-        if (orbInstance_ != null) {
-            SHUTDOWN_LOG.fine(() -> "ORB.destroy() was not called. This may result in resource leaks.");
-        }
-        super.finalize();
-    }
-
     private void initializeDefaultPolicies() {
         Properties properties = orbInstance_.getProperties();
 

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/ActiveObjectOnlyStrategy.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/ActiveObjectOnlyStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 IBM Corporation and others.
+ * Copyright 2026 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,11 +65,6 @@ class DirectSeqEntry {
     DirectSeqEntry(byte[] oid) {
         seq_ = new Vector();
         oid_ = oid;
-    }
-
-    protected void finalize() throws Throwable {
-        deactivate();
-        super.finalize();
     }
 
     void deactivate() {

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/DirectServant.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/DirectServant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 IBM Corporation and others.
+ * Copyright 2026 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class DirectServant extends ServantObject {
     // This flag is true if the servant has been deactivated
     //
     private boolean deactivated_;
-    
+
 	private Object original_servant;
 
     public DirectServant(POA_impl poa,
@@ -53,15 +53,6 @@ public class DirectServant extends ServantObject {
             Tie tie = (Tie) servant;
             this.servant = tie.getTarget();
         }
-    }
-
-    protected void finalize() throws Throwable {
-        //
-        // This object *must* have been deactivated already
-        //
-        ensure(deactivated_);
-
-        super.finalize();
     }
 
     public void destroy() {

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/POA_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/POA_impl.java
@@ -388,11 +388,6 @@ final public class POA_impl extends LocalObject implements POA {
         };
     }
 
-    @SuppressWarnings("deprecation")
-    protected void finalize() throws Throwable {
-        Assert.ensure(poaControl_.getDestroyed());
-        super.finalize();
-    }
 
     // ----------------------------------------------------------------------
     // Standard IDL to Java mapping

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OCI/IIOP/Acceptor_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OCI/IIOP/Acceptor_impl.java
@@ -311,18 +311,6 @@ final class Acceptor_impl extends LocalObject implements Acceptor {
         }
     }
 
-    // TODO: get rid of this finalizer, and use phantom refs in AccFactory_impl instead to track Acceptors going away.
-    protected void finalize() throws Throwable {
-        if (socket_ != null) {
-            close();
-        }
-
-        // remove this acceptor from the listenMap_
-        synchronized (listenMap_) {
-            for (String s : hosts_) listenMap_.remove(s, (short) port_);
-        }
-    }
-
     public String toString() {
         return "Acceptor listening on " + socket_;
     }

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OCI/IIOP/Connector_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OCI/IIOP/Connector_impl.java
@@ -363,13 +363,6 @@ final class Connector_impl extends org.omg.CORBA.LocalObject implements Connecto
         transportInfo = extractTransportInfo(ior);
     }
 
-    protected void finalize() throws Throwable {
-        if (socket_ != null)
-            close();
-
-        super.finalize();
-    }
-
     @Override
     public String toString() {
         return "-> " + info_;

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OCI/IIOP/Transport_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OCI/IIOP/Transport_impl.java
@@ -319,13 +319,6 @@ final public class Transport_impl extends LocalObject implements Transport {
         info_ = new TransportInfo_impl(this, acceptor, lm);
     }
 
-    public void finalize() throws Throwable {
-        if (socket_ != null)
-            close();
-
-        super.finalize();
-    }
-
     public String toString() {
         return String.format("Transport to %s with socket %s", info_, socket_);
     }

--- a/yoko-core/src/main/java/org/apache/yoko/orb/PortableServer/PoaCurrentImpl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/PortableServer/PoaCurrentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 IBM Corporation and others.
+ * Copyright 2026 IBM Corporation and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,9 +39,6 @@ final public class PoaCurrentImpl extends org.omg.CORBA.LocalObject implements o
     public PoaCurrentImpl() {
     }
 
-    protected void finalize() throws Throwable {
-        super.finalize();
-    }
 
     public org.omg.PortableServer.POA get_POA()
             throws org.omg.PortableServer.CurrentPackage.NoContext {

--- a/yoko-util/src/main/java/org/apache/yoko/util/concurrent/YokoCleaner.java
+++ b/yoko-util/src/main/java/org/apache/yoko/util/concurrent/YokoCleaner.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.yoko.util.concurrent;
+
+import org.apache.yoko.io.SimplyCloseable;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+/**
+ * A Java 8-compatible implementation of automatic resource cleanup similar to Java 9's {@code java.lang.ref.Cleaner}.
+ *
+ * <p>This class uses {@link PhantomReference} and {@link ReferenceQueue} to detect when objects become
+ * phantom reachable (i.e., eligible for garbage collection) and automatically executes registered cleanup actions.
+ *
+ * <p>All YokoCleaner instances share a single daemon thread for processing cleanup actions, reducing
+ * thread overhead in applications with multiple cleaner instances.
+ *
+ * <p><strong>Usage Example:</strong>
+ * <pre>{@code
+ * public class ResourceHolder {
+ *     private static final YokoCleaner cleaner = YokoCleaner.create();
+ *     private final SimplyCloseable cleanable;
+ *
+ *     public ResourceHolder() {
+ *         // Register cleanup action that will run when this object is GC'd
+ *         this.cleanable = cleaner.register(this, () -> {
+ *             // Cleanup code here - must not reference 'this'
+ *             closeNativeResource();
+ *         });
+ *     }
+ *
+ *     public void close() {
+ *         // Manually trigger cleanup if needed
+ *         cleanable.close();
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p><strong>Important Notes:</strong>
+ * <ul>
+ *   <li>The cleanup action must NOT hold a strong reference to the object being monitored</li>
+ *   <li>Cleanup actions run on a shared daemon thread</li>
+ *   <li>Exceptions thrown by cleanup actions are logged but do not stop the cleaner thread</li>
+ *   <li>The returned {@link SimplyCloseable} is idempotent - multiple calls to {@code close()} are safe</li>
+ *   <li>All threads calling {@code close()} will block until the cleanup action completes</li>
+ * </ul>
+ *
+ * @see java.lang.ref.Cleaner
+ * @see java.lang.ref.PhantomReference
+ */
+public final class YokoCleaner {
+    private static final Logger logger = Logger.getLogger(YokoCleaner.class.getName());
+
+    // Shared queue and cleaner thread for all YokoCleaner instances
+    private static final ReferenceQueue<Object> SHARED_QUEUE = new ReferenceQueue<>();
+    private static final LazyReference<Void> lazyCleanupThread = new LazyReference<>(YokoCleaner::startCleanupThread);
+
+    private static Void startCleanupThread() {
+        Thread thread = new Thread(YokoCleaner::processQueue, "YokoCleaner-Thread");
+        thread.setDaemon(true);
+        thread.start();
+        return null;
+    }
+
+    private final Set<PhantomCleanable<?>> cleanables = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Creates a new cleaner instance. All instances share a single daemon thread for processing cleanup actions.
+     *
+     * @return a new cleaner instance
+     */
+    public static YokoCleaner create() { return new YokoCleaner(); }
+
+    private YokoCleaner() {
+        // Nothing to initialize - uses shared static resources
+    }
+
+    /**
+     * Registers an object and a cleanup action to be executed when the object becomes phantom reachable.
+     *
+     * <p><strong>CRITICAL:</strong> The cleanup action must NOT hold a strong reference to the object being
+     * monitored, otherwise the object will never become phantom reachable and the cleanup will never run.
+     *
+     * <p>The returned {@link SimplyCloseable} can be used to manually trigger cleanup before garbage collection.
+     * Calling {@code close()} is idempotent and thread-safe - all threads will block until cleanup completes.
+     *
+     * @param obj the object to monitor for garbage collection
+     * @param action the cleanup action to execute (must not reference {@code obj})
+     * @return a {@link SimplyCloseable} that can be used to manually trigger cleanup
+     * @throws NullPointerException if obj or action is null
+     */
+    public SimplyCloseable register(Object obj, Runnable action) {
+        Objects.requireNonNull(obj, "obj must not be null");
+        Objects.requireNonNull(action, "action must not be null");
+
+        // Ensure cleaner thread is started on first registration
+        lazyCleanupThread.get();
+
+        return PhantomCleanable.create(obj, action, cleanables);
+    }
+
+    private static void processQueue() {
+        logger.info("YokoCleaner thread started");
+        for (;;) {
+            try {
+                // Block until a reference is available
+                PhantomCleanable<?> ref = (PhantomCleanable<?>) SHARED_QUEUE.remove();
+                ref.close();
+            } catch (InterruptedException e) {
+                // Continue processing - daemon thread runs forever
+            } catch (Throwable t) {
+                // Log but don't stop the cleaner thread - catch Throwable to ensure thread continues
+                logger.warning("Exception in YokoCleaner cleanup action: " + t);
+            }
+        }
+    }
+
+    private static final class PhantomCleanable<T> extends PhantomReference<T> implements SimplyCloseable {
+        private final LazyReference<Void> lazyCleanup;
+
+        static <T> PhantomCleanable<T> create(T referent, Runnable action, Set<PhantomCleanable<?>> cleanables) {
+            PhantomCleanable<T> cleanable = new PhantomCleanable<>(referent, YokoCleaner.SHARED_QUEUE, action, cleanables);
+            cleanables.add(cleanable);
+            return cleanable;
+        }
+
+        private PhantomCleanable(T referent, ReferenceQueue<? super T> queue, Runnable action, Set<PhantomCleanable<?>> cleanables) {
+            super(referent, queue);
+            // Use LazyReference to ensure cleanup happens exactly once
+            // and all threads wait for completion
+            this.lazyCleanup = new LazyReference<>(() -> {
+                try {
+                    action.run();
+                } catch (Throwable t) {
+                    // Log but don't propagate exceptions from cleanup actions
+                    logger.warning("Exception in cleanup action: " + t);
+                } finally {
+                    cleanables.remove(this);
+                    clear();
+                }
+                return null;
+            });
+        }
+
+        @Override
+        public void close() { lazyCleanup.get(); }
+    }
+}

--- a/yoko-util/src/test/java/org/apache/yoko/util/concurrent/YokoCleanerTest.java
+++ b/yoko-util/src/test/java/org/apache/yoko/util/concurrent/YokoCleanerTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 IBM Corporation and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.apache.yoko.util.concurrent;
+
+import org.apache.yoko.io.SimplyCloseable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class YokoCleanerTest {
+
+    private YokoCleaner cleaner;
+
+    @BeforeEach
+    public void setUp() {
+        cleaner = YokoCleaner.create();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        // No shutdown needed - singleton cleaner thread runs forever
+    }
+
+    @Test
+    public void testManualCleanup() throws Exception {
+        AtomicInteger cleanupCount = new AtomicInteger(0);
+        Object obj = new Object();
+
+        SimplyCloseable cleanable = cleaner.register(obj, cleanupCount::incrementAndGet);
+
+        // Manually trigger cleanup
+        cleanable.close();
+
+        assertEquals(1, cleanupCount.get(), "Cleanup should have been called once");
+    }
+
+    @Test
+    public void testIdempotentCleanup() throws Exception {
+        AtomicInteger cleanupCount = new AtomicInteger(0);
+        Object obj = new Object();
+
+        SimplyCloseable cleanable = cleaner.register(obj, cleanupCount::incrementAndGet);
+
+        // Call close multiple times
+        cleanable.close();
+        cleanable.close();
+        cleanable.close();
+
+        assertEquals(1, cleanupCount.get(), "Cleanup should have been called exactly once despite multiple close() calls");
+    }
+
+    @Test
+    public void testConcurrentCleanup() throws Exception {
+        AtomicInteger cleanupCount = new AtomicInteger(0);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(5);
+        Object obj = new Object();
+
+        SimplyCloseable cleanable = cleaner.register(obj, () -> {
+            cleanupCount.incrementAndGet();
+            try {
+                Thread.sleep(100); // Simulate some work
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        // Start 5 threads that all try to close concurrently
+        for (int i = 0; i < 5; i++) {
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    cleanable.close();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            }).start();
+        }
+
+        startLatch.countDown(); // Start all threads
+        assertTrue(doneLatch.await(5, TimeUnit.SECONDS), "All threads should complete");
+        assertEquals(1, cleanupCount.get(), "Cleanup should have been called exactly once despite concurrent close() calls");
+    }
+
+    @Test
+    public void testAutomaticCleanupOnGC() throws Exception {
+        AtomicInteger cleanupCount = new AtomicInteger(0);
+        CountDownLatch cleanupLatch = new CountDownLatch(1);
+
+        // Create object in a separate scope so it can be GC'd
+        createAndRegisterObject(cleanupCount, cleanupLatch);
+
+        // Force garbage collection
+        for (int i = 0; i < 10; i++) {
+            System.gc();
+            System.runFinalization();
+            if (cleanupLatch.await(100, TimeUnit.MILLISECONDS)) {
+                break;
+            }
+        }
+
+        assertTrue(cleanupLatch.await(5, TimeUnit.SECONDS), "Cleanup should have been triggered by GC");
+        assertEquals(1, cleanupCount.get(), "Cleanup should have been called once");
+    }
+
+    private void createAndRegisterObject(AtomicInteger cleanupCount, CountDownLatch cleanupLatch) {
+        Object obj = new Object();
+        cleaner.register(obj, () -> {
+            cleanupCount.incrementAndGet();
+            cleanupLatch.countDown();
+        });
+        // obj goes out of scope here and becomes eligible for GC
+    }
+
+    @Test
+    public void testCleanupWithException() throws Exception {
+        AtomicInteger cleanupCount = new AtomicInteger(0);
+        Object obj = new Object();
+
+        SimplyCloseable cleanable = cleaner.register(obj, () -> {
+            cleanupCount.incrementAndGet();
+            throw new RuntimeException("Test exception");
+        });
+
+        // Should not throw exception to caller
+        assertDoesNotThrow(cleanable::close);
+        assertEquals(1, cleanupCount.get(), "Cleanup should have been called despite exception");
+    }
+
+    @Test
+    public void testNullObjectThrowsException() {
+        assertThrows(NullPointerException.class, () -> {
+            cleaner.register(null, () -> {});
+        });
+    }
+
+    @Test
+    public void testNullActionThrowsException() {
+        assertThrows(NullPointerException.class, () -> {
+            cleaner.register(new Object(), null);
+        });
+    }
+
+    @Test
+    public void testMultipleRegistrations() throws Exception {
+        AtomicInteger cleanup1Count = new AtomicInteger(0);
+        AtomicInteger cleanup2Count = new AtomicInteger(0);
+        AtomicInteger cleanup3Count = new AtomicInteger(0);
+
+        Object obj1 = new Object();
+        Object obj2 = new Object();
+        Object obj3 = new Object();
+
+        SimplyCloseable cleanable1 = cleaner.register(obj1, cleanup1Count::incrementAndGet);
+        SimplyCloseable cleanable2 = cleaner.register(obj2, cleanup2Count::incrementAndGet);
+        SimplyCloseable cleanable3 = cleaner.register(obj3, cleanup3Count::incrementAndGet);
+
+        cleanable1.close();
+        cleanable2.close();
+        cleanable3.close();
+
+        assertEquals(1, cleanup1Count.get());
+        assertEquals(1, cleanup2Count.get());
+        assertEquals(1, cleanup3Count.get());
+    }
+
+    @Test
+    public void testCleanupActionDoesNotReferenceObject() throws Exception {
+        // This test verifies the pattern where cleanup action must not reference the monitored object
+        AtomicInteger cleanupCount = new AtomicInteger(0);
+
+        class Resource {
+            private final int id;
+            Resource(int id) { this.id = id; }
+            int getId() { return id; }
+        }
+
+        Resource resource = new Resource(42);
+        int capturedId = resource.getId(); // Capture value, not reference
+
+        SimplyCloseable cleanable = cleaner.register(resource, () -> {
+            // This is correct - uses captured primitive value, not object reference
+            cleanupCount.addAndGet(capturedId);
+        });
+
+        cleanable.close();
+        assertEquals(42, cleanupCount.get());
+    }
+
+
+}


### PR DESCRIPTION
- **refactor(rmi-impl): use ClassValue instead of Map for stub caching**
- **refactor(rmi-impl): make MethodRef immutable with lazy initialization**
- **refactor(rmi-impl): use MethodHandles and Supplier pattern for stub creation**
- **refactor(rmi-impl): use MethodHandles for Externalizable object instantiation**
- **refactor(yoko-util,yoko-core): use MethodHandles for simple constructors**
- **refactor(yoko-core): remove assertion-only finalize() methods**
- **feat(yoko-util): add YokoCleaner for Java 8-compatible resource cleanup**
- **refactor: Replace DowncallStub finalizer with YokoCleaner**
- **refactor(yoko-core): remove assertion-only finalizers from GIOPServerStarter and GIOPServer**
- **refactor(yoko-core): remove Request finalizer**
- **refactor(yoko-core): remove finalizers from Delegate and DirectServant**
- **refactor(yoko-core): remove finalizer from ActiveObjectOnlyStrategy**
- **refactor(yoko-core): remove finalizer from Transport_impl**
- **refactor(yoko-core): remove finalizer from Connector_impl**
- **refactor(yoko-core): remove finalizer from ORB_impl**
- **refactor(yoko-core): remove finalizer from Acceptor_impl**

Fixes #804 
