### PR TITLE
refactor(logging): improve logging across POA and interceptor components

### DIFF
--- a/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/POAPolicies.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/POAPolicies.java
@@ -79,6 +79,10 @@ final public class POAPolicies {
     private final short bidirPolicyValue;
 
     POAPolicies(ORBInstance orbInstance, Policy[] policies) {
+        this(orbInstance, policies, null);
+    }
+
+    POAPolicies(ORBInstance orbInstance, Policy[] policies, String poaName) {
         // Set the default policy values.
         // These are temporary variables to allow the final fields to be set after the for loop.
         // TODO: refactor to use a builder pattern for conciseness
@@ -113,8 +117,9 @@ final public class POAPolicies {
                     case INTERCEPTOR_CALL_POLICY_ID.value: interceptorCall = InterceptorCallPolicyHelper.narrow(InterceptorCallPolicyHelper.narrow(policy)).value(); break;
                     case ZERO_PORT_POLICY_ID.value: zeroPort = ZeroPortPolicyHelper.narrow(ZeroPortPolicyHelper.narrow(policy)).value(); break;
                     default:
-                        // Unknown policy
-                        POA_INIT_LOG.warning(() -> String.format("Ignoring unsupported policy of type 0x%x", policy.policy_type()));
+                        // Unknown policy - log at fine level since this is expected when new policies are introduced
+                        final String poa = poaName != null ? "POA '" + poaName + "' is ignoring" : "Ignoring";
+                        POA_INIT_LOG.fine(() -> String.format("%s unsupported policy of type 0x%x", poa, policy.policy_type()));
                 }
             }
         }

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/POAPolicies.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/POAPolicies.java
@@ -54,6 +54,8 @@ import org.omg.PortableServer.THREAD_POLICY_ID;
 import org.omg.PortableServer.ThreadPolicyHelper;
 import org.omg.PortableServer.ThreadPolicyValue;
 
+import java.util.Optional;
+
 import static org.apache.yoko.logging.VerboseLogging.POA_INIT_LOG;
 import static org.apache.yoko.orb.OBPortableServer.SynchronizationPolicyValue.NO_SYNCHRONIZATION;
 import static org.apache.yoko.orb.OBPortableServer.SynchronizationPolicyValue.SYNCHRONIZE_ON_ORB;
@@ -99,7 +101,7 @@ final public class POAPolicies {
         DispatchStrategy dispatchStrategy = null;
         short bidir = BOTH.value;
 
-        if (policies != null) {
+        if (null != policies) {
             for (Policy policy : policies) {
                 switch (policy.policy_type()) {
                     // CORBA standard policies
@@ -118,8 +120,7 @@ final public class POAPolicies {
                     case ZERO_PORT_POLICY_ID.value: zeroPort = ZeroPortPolicyHelper.narrow(ZeroPortPolicyHelper.narrow(policy)).value(); break;
                     default:
                         // Unknown policy - log at fine level since this is expected when new policies are introduced
-                        final String poa = poaName != null ? "POA '" + poaName + "' is ignoring" : "Ignoring";
-                        POA_INIT_LOG.fine(() -> String.format("%s unsupported policy of type 0x%x", poa, policy.policy_type()));
+                        POA_INIT_LOG.fine(() -> String.format("%s unsupported policy of type 0x%x", null == poaName ? "Ignoring" : "POA '" + poaName + "' is ignoring", policy.policy_type()));
                 }
             }
         }
@@ -133,18 +134,10 @@ final public class POAPolicies {
         idAssignmentPolicy = idAssignment;
         idUniquenessPolicy = idUniqueness;
         lifespanPolicy = lifespan;
-        // the synchronization policy can be set explicitly (proprietary), or derived from the thread policy (standard)
-        if (null == synchronization) {
-            // only consider the thread policy if there was no explicit synchronization policy
-            synchronizationPolicy = SINGLE_THREAD_MODEL == thread ? SYNCHRONIZE_ON_ORB : NO_SYNCHRONIZATION;
-        } else {
-            synchronizationPolicy = synchronization;
-        }
-        if (dispatchStrategy == null) {
-            DispatchStrategyFactory dsf = orbInstance.getDispatchStrategyFactory();
-            dispatchStrategy = dsf.create_default_dispatch_strategy();
-        }
-        dispatchStrategyPolicy = dispatchStrategy;
+        synchronizationPolicy = Optional.ofNullable(synchronization) // the synchronization policy can be set explicitly (proprietary),
+                .orElse(SINGLE_THREAD_MODEL == thread ? SYNCHRONIZE_ON_ORB : NO_SYNCHRONIZATION); // or derived from the thread policy (standard)
+        dispatchStrategyPolicy = Optional.ofNullable(dispatchStrategy)
+                .orElseGet(orbInstance.getDispatchStrategyFactory()::create_default_dispatch_strategy);
     }
 
     public boolean interceptorCallPolicy() {

--- a/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/POA_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/OBPortableServer/POA_impl.java
@@ -410,7 +410,7 @@ final public class POA_impl extends LocalObject implements POA {
         logger.fine(() -> "POA " + name_ + " creating new POA with name " + adapter);
 
         // Are the requested policies valid?
-        POAPolicies policies = new POAPolicies(orbInstance_, rawPolicies);
+        POAPolicies policies = new POAPolicies(orbInstance_, rawPolicies, adapter);
         IntHolder idx = new IntHolder();
         if (!validatePolicies(policies, rawPolicies, idx))
             throw new InvalidPolicy((short) idx.value);

--- a/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ServerRequestInfo_impl.java
+++ b/yoko-core/src/main/java/org/apache/yoko/orb/PortableInterceptor/ServerRequestInfo_impl.java
@@ -58,7 +58,7 @@ import org.omg.PortableServer.Servant;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.apache.yoko.logging.VerboseLogging.REQ_OUT_LOG;
+import static org.apache.yoko.logging.VerboseLogging.REQ_IN_LOG;
 import static org.apache.yoko.util.CollectionExtras.newSynchronizedList;
 import static org.apache.yoko.util.CollectionExtras.removeInReverse;
 import static org.apache.yoko.util.MinorCodes.MinorInvalidPICall;
@@ -349,7 +349,7 @@ final public class ServerRequestInfo_impl extends RequestInfo_impl implements Se
                     // correct completion status
                     CompletionStatus expected = oldE instanceof SystemException ? ((SystemException)oldE).completed : COMPLETED_YES;
                     if (expected != newE.completed) {
-                        REQ_OUT_LOG.warning(() -> "Correcting completion status on new exception from interceptor " + i.getClass() + ": was " + newE.completed + " and is: " + expected);
+                        REQ_IN_LOG.warning(() -> "Correcting completion status on new exception from interceptor " + i.getClass() + ": was " + newE.completed + " and is: " + expected);
                         newE.completed = expected;
                     }
                     throw newE;
@@ -382,7 +382,7 @@ final public class ServerRequestInfo_impl extends RequestInfo_impl implements Se
                 } catch (SystemException newE) {
                     // correct completion status
                     if (COMPLETED_NO != newE.completed) {
-                        REQ_OUT_LOG.warning(() -> "Correcting completion status on new exception from interceptor " + i.getClass() + ": was " + newE.completed + " and is: " + COMPLETED_NO);
+                        REQ_IN_LOG.warning(() -> "Correcting completion status on new exception from interceptor " + i.getClass() + ": was " + newE.completed + " and is: " + COMPLETED_NO);
                         newE.completed = COMPLETED_NO;
                     }
                     throw newE;


### PR DESCRIPTION
Cherry-picks the logging improvements from `dev` into the rewound `main` baseline (v1.6.1).

## Changes

- **`ServerRequestInfo_impl`** — correct logger usage (use class-level logger instead of wrong instance)
- **`POA_impl` / `POAPolicies`** — improve unsupported policy logging with POA name and reduced severity; simplify POA initialisation logic

## Commits

- `refactor(logging): correct logger usage in ServerRequestInfo_impl`
- `style(poa): improve unsupported policy logging with POA name and reduced severity`
- `style: improve POA initialisation logic`